### PR TITLE
Fix Prompti capitalization in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# PromptI
+# Prompti
 
-PromptI is a provider‑agnostic asynchronous prompt engine built around the
+Prompti is a provider‑agnostic asynchronous prompt engine built around the
 Agent‑to‑Agent (A2A) message format. Prompts are stored as Jinja templates and
 may be loaded from disk, memory or a remote registry. All LLM calls are routed
 through a pluggable `ModelClient` so that calling code never deals with


### PR DESCRIPTION
## Summary
- fix heading and description in the README to use `Prompti`

## Testing
- `uv pip install --system -e .[test]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685289e47b448320bc784d00d0a81a0f