### PR TITLE
Remove git commit field

### DIFF
--- a/prompti/engine.py
+++ b/prompti/engine.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 from typing import Any, AsyncGenerator, Awaitable, Callable, Tuple, Dict
-import subprocess
 
 from async_lru import alru_cache
 from pydantic import BaseModel
@@ -24,20 +23,11 @@ class FileSystemLoader:
         path = self.base / f"{name}.jinja"
         text = path.read_text()
         version = "1.0.0"
-        try:
-            commit = (
-                subprocess.check_output(["git", "rev-parse", "HEAD"], stderr=subprocess.DEVNULL)
-                .decode()
-                .strip()
-            )
-        except Exception:
-            commit = None
         tmpl = PromptTemplate(
             id=name,
             name=name,
             version=version,
             jinja_source=text,
-            git_commit_id=commit,
         )
         return version, tmpl
 

--- a/prompti/loaders.py
+++ b/prompti/loaders.py
@@ -19,13 +19,11 @@ class MemoryLoader:
         if not data:
             raise FileNotFoundError(name)
         version = data.get("version", "0")
-        commit = data.get("git_commit_id")
         tmpl = PromptTemplate(
             id=name,
             name=name,
             version=version,
             jinja_source=data.get("jinja", ""),
-            git_commit_id=commit,
         )
         return version, tmpl
 
@@ -42,12 +40,10 @@ class HTTPLoader:
             raise FileNotFoundError(name)
         data = resp.json()
         version = data["version"]
-        commit = data.get("git_commit_id")
         tmpl = PromptTemplate(
             id=name,
             name=name,
             version=version,
             jinja_source=data["jinja"],
-            git_commit_id=commit,
         )
         return version, tmpl

--- a/prompti/template.py
+++ b/prompti/template.py
@@ -15,7 +15,6 @@ class PromptTemplate(BaseModel):
     name: str
     version: str
     jinja_source: str
-    git_commit_id: str | None = None
     tags: set[str] = set()
 
     def format(

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -11,9 +11,3 @@ async def test_format_basic():
     assert messages[0].content.startswith("Hello Ada")
 
 
-@pytest.mark.asyncio
-async def test_git_commit_id():
-    settings = Setting(template_paths=["./prompts"])
-    engine = PromptEngine.from_setting(settings)
-    tmpl = await engine._resolve("support_reply", None)
-    assert tmpl.git_commit_id is not None


### PR DESCRIPTION
## Summary
- drop the `git_commit_id` field from `PromptTemplate`
- simplify loaders and engine accordingly
- remove obsolete test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852e39c698083209f5d0909e716f9db