### PR TITLE
Add replay subsystem

### DIFF
--- a/prompti/__init__.py
+++ b/prompti/__init__.py
@@ -11,6 +11,7 @@ from .model_client import (
     LiteLLMClient,
     OpenRouterClient,
 )
+from .replay import ReplayEngine, ModelClientRecorder
 
 __all__ = [
     "Message",
@@ -22,4 +23,6 @@ __all__ = [
     "ClaudeClient",
     "LiteLLMClient",
     "OpenRouterClient",
+    "ReplayEngine",
+    "ModelClientRecorder",
 ]

--- a/prompti/replay.py
+++ b/prompti/replay.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+"""Replay and recording utilities."""
+
+import json
+from pathlib import Path
+from typing import AsyncGenerator, Iterable, Callable
+from uuid import uuid4
+from datetime import datetime, timezone
+
+import aiofiles
+from prometheus_client import Counter
+
+from .message import Message
+from .model_client import ModelClient, ModelConfig
+
+
+class ReplayError(Exception):
+    """Raised when replay encounters an error event."""
+
+
+_replay_counter = Counter(
+    "trace_replay_total", "replay summary", labelnames=["status"]
+)
+_diff_tokens = Counter("trace_diff_tokens_total", "token diff")
+
+
+class ModelClientRecorder(ModelClient):
+    """Wrapper around :class:`ModelClient` that records all I/O."""
+
+    def __init__(
+        self,
+        client: ModelClient,
+        session_id: str,
+        output_dir: str | Path | None = None,
+    ) -> None:
+        super().__init__(client=client._client)
+        self._wrapped = client
+        self.session_id = session_id
+        self.output_dir = Path(output_dir or Path.home() / ".prompt/sessions")
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+    async def _write_row(
+        self, file, step: int, direction: str, payload: dict | list, meta: dict
+    ) -> None:
+        row = {
+            "session_id": self.session_id,
+            "trace_id": self._trace_id,
+            "step": step,
+            "direction": direction,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "payload": payload,
+            "meta": meta,
+        }
+        await file.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+    async def _run(
+        self, messages: list[Message], model_cfg: ModelConfig
+    ) -> AsyncGenerator[Message, None]:
+        self._trace_id = str(uuid4())
+        step = 0
+        meta = {"provider": model_cfg.provider, "model": model_cfg.model}
+        log_file = (
+            self.output_dir
+            / f"rollout-{datetime.now(timezone.utc).date().isoformat()}-{self.session_id}.jsonl"
+        )
+        async with aiofiles.open(log_file, "a") as f:
+            await self._write_row(
+                f,
+                step,
+                "req",
+                [m.model_dump() for m in messages],
+                meta,
+            )
+            step += 1
+            try:
+                async for msg in self._wrapped.run(messages, model_cfg):
+                    direction = "delta" if msg.kind == "tool_use" else "res"
+                    await self._write_row(f, step, direction, msg.model_dump(), meta)
+                    step += 1
+                    yield msg
+            except Exception as exc:
+                await self._write_row(
+                    f, step, "error", {"error": str(exc)}, meta
+                )
+                raise
+
+    async def close(self) -> None:
+        await self._wrapped.close()
+
+
+class ReplayEngine:
+    """Replays a recorded trace."""
+
+    def __init__(self, client_factory: Callable[[str], ModelClient]):
+        """Create with a ``client_factory`` mapping provider -> ModelClient."""
+
+        self._client_factory = client_factory
+        self._clients: dict[str, ModelClient] = {}
+
+    def _get_client(self, provider: str) -> ModelClient:
+        if provider not in self._clients:
+            self._clients[provider] = self._client_factory(provider)
+        return self._clients[provider]
+
+    async def replay(
+        self,
+        rows: Iterable[dict],
+        up_to_step: int | None = None,
+        patch: dict[int, list[Message]] | None = None,
+    ) -> AsyncGenerator[Message, None]:
+        patch = patch or {}
+        status = "ok"
+        try:
+            for row in sorted(rows, key=lambda r: r["step"]):
+                if up_to_step is not None and row["step"] > up_to_step:
+                    break
+                direction = row["direction"]
+                if direction == "req":
+                    step = row["step"]
+                    msgs = patch.get(step)
+                    if msgs is None:
+                        msgs = [Message(**m) for m in row["payload"]]
+                    meta = row.get("meta", {})
+                    provider = meta.get("provider", "")
+                    model = meta.get("model", "")
+                    client = self._get_client(provider)
+                    cfg = ModelConfig(provider=provider, model=model)
+                    async for m in client.run(msgs, cfg):
+                        yield m
+                elif direction in ("delta", "res", "tool_result"):
+                    yield Message(**row["payload"])
+                elif direction == "error":
+                    status = "fail"
+                    raise ReplayError(row.get("payload"))
+        finally:
+            _replay_counter.labels(status).inc()
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ dependencies = [
   "async-lru",
   "httpx>=0.25",
   "tenacity>=8",
+  "aiofiles",
+  "pyyaml",
   "prometheus-client",
   "opentelemetry-api",
   "opentelemetry-sdk",

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -1,0 +1,40 @@
+import json
+import asyncio
+
+import pytest
+import httpx
+from httpx import Response, Request
+
+from prompti import (
+    Message,
+    ModelConfig,
+    OpenAIClient,
+    ModelClientRecorder,
+    ReplayEngine,
+)
+
+
+@pytest.mark.asyncio
+async def test_record_and_replay(tmp_path):
+    async def handler(request: Request):
+        return Response(200, json={"choices": [{"message": {"content": "pong"}}]})
+
+    transport = httpx.MockTransport(handler)
+    base = OpenAIClient(client=httpx.AsyncClient(transport=transport))
+    recorder = ModelClientRecorder(base, "sess", output_dir=tmp_path)
+    cfg = ModelConfig(provider="openai", model="gpt-4o")
+    msgs = [Message(role="user", kind="text", content="ping")]
+    result = [m async for m in recorder.run(msgs, cfg)]
+    assert result[0].content == "pong"
+
+    log_file = next(tmp_path.iterdir())
+    rows = [json.loads(l) for l in log_file.read_text().splitlines()]
+    assert rows[0]["direction"] == "req"
+    assert rows[1]["direction"] == "res"
+
+    def factory(provider: str):
+        return OpenAIClient(client=httpx.AsyncClient(transport=transport))
+
+    engine = ReplayEngine(factory)
+    out = [m async for m in engine.replay(rows)]
+    assert out[0].content == "pong"


### PR DESCRIPTION
## Summary
- implement `ModelClientRecorder` to log LLM requests and responses
- implement `ReplayEngine` to replay recorded sessions
- expose new classes in `__init__`
- depend on `aiofiles` and `pyyaml`
- test recording and replaying a conversation

## Testing
- `uv pip install --system -e .[test]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685367a3a7848320866a2b1f6f9a805d