### PR TITLE
Add SDK split support with registry variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,7 @@ and **LiteLLM**.  Each provider has its own `ModelClient` subclass (e.g.
 `OpenAIClient`).  Set the corresponding API key environment variables such as
 `OPENAI_API_KEY` before running examples.
 
+Prompti also supports SDK-level A/B experiments via the `ExperimentRegistry`
+interface with built-in **Unleash** and **GrowthBook** adapters.
+
 See `DESIGN.md` for a more detailed description of the architecture.

--- a/prompti/__init__.py
+++ b/prompti/__init__.py
@@ -12,6 +12,13 @@ from .model_client import (
     OpenRouterClient,
 )
 from .replay import ReplayEngine, ModelClientRecorder
+from .experiment import (
+    ExperimentRegistry,
+    ExperimentSplit,
+    UnleashRegistry,
+    GrowthBookRegistry,
+    bucket,
+)
 
 __all__ = [
     "Message",
@@ -25,4 +32,9 @@ __all__ = [
     "OpenRouterClient",
     "ReplayEngine",
     "ModelClientRecorder",
+    "ExperimentRegistry",
+    "ExperimentSplit",
+    "UnleashRegistry",
+    "GrowthBookRegistry",
+    "bucket",
 ]

--- a/prompti/experiment.py
+++ b/prompti/experiment.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+"""SDK level A/B experiment helpers."""
+
+from typing import Protocol, Dict
+from pydantic import BaseModel
+import httpx
+import xxhash
+
+
+class ExperimentSplit(BaseModel):
+    """Result of an experiment lookup."""
+
+    experiment_id: str | None = None
+    variant: str | None = None
+    traffic_split: Dict[str, float] | None = None
+
+
+class ExperimentRegistry(Protocol):
+    """Lookup experiment variant for a prompt/user."""
+
+    async def get_split(self, prompt: str, user_id: str) -> ExperimentSplit:
+        """Return the experiment split for ``prompt`` and ``user_id``."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Hashing utilities
+# ---------------------------------------------------------------------------
+
+def bucket(hash_key: str, split: Dict[str, float]) -> str:
+    """Return variant bucket using xxhash based distribution."""
+    h = xxhash.xxh32(hash_key).intdigest() / 2**32
+    total = 0.0
+    for variant, pct in split.items():
+        total += pct
+        if h < total:
+            return variant
+    return next(iter(split))
+
+
+# ---------------------------------------------------------------------------
+# Unleash adapter
+# ---------------------------------------------------------------------------
+
+class UnleashRegistry:
+    """Experiment registry that queries an Unleash server."""
+
+    def __init__(self, base_url: str, client: httpx.AsyncClient | None = None) -> None:
+        """Create registry using ``base_url`` and optional HTTP ``client``."""
+        self.base_url = base_url.rstrip("/")
+        self._client = client or httpx.AsyncClient()
+
+    async def get_split(self, prompt: str, user_id: str) -> ExperimentSplit:
+        """Resolve the split for ``prompt`` from the Unleash server."""
+        url = f"{self.base_url}/client/features/{prompt}"
+        resp = await self._client.get(
+            url,
+            headers={
+                "UNLEASH-APPNAME": "prompti",
+                "UNLEASH-INSTANCEID": user_id,
+            },
+        )
+        data = resp.json()
+        variant = None
+        if isinstance(data, dict):
+            variant = (data.get("variant") or {}).get("name")
+        if not variant or variant == "disabled":
+            return ExperimentSplit()
+        return ExperimentSplit(experiment_id=data.get("name"), variant=variant)
+
+
+# ---------------------------------------------------------------------------
+# GrowthBook adapter
+# ---------------------------------------------------------------------------
+
+class GrowthBookRegistry:
+    """Simple GrowthBook adapter using an in-memory feature map."""
+
+    def __init__(self, features: Dict[str, Dict[str, float | str]]) -> None:
+        """Initialize with ``features`` describing experiments and weights."""
+        self._features = features
+
+    async def get_split(self, prompt: str, user_id: str) -> ExperimentSplit:
+        """Return the configuration for ``prompt`` without selecting a variant."""
+        conf = self._features.get(prompt)
+        if not conf:
+            return ExperimentSplit()
+        variants = conf.get("variants", {})
+        if not variants:
+            return ExperimentSplit()
+        exp_id = conf.get("id", prompt)
+        return ExperimentSplit(experiment_id=exp_id, traffic_split=variants)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
   "prometheus-client",
   "opentelemetry-api",
   "opentelemetry-sdk",
+  "xxhash",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1,0 +1,69 @@
+"""Unit tests for ExperimentRegistry adapters and utilities."""
+
+import httpx
+from httpx import Response, Request
+import pytest
+
+from prompti.experiment import bucket, UnleashRegistry, GrowthBookRegistry
+from prompti.engine import PromptEngine, Setting
+from prompti.model_client import ModelClient, ModelConfig
+from prompti import Message
+
+
+def test_bucket_deterministic():
+    split = {"A": 0.5, "B": 0.5}
+    assert bucket("user1", split) == bucket("user1", split)
+    assert bucket("user1", split) in {"A", "B"}
+
+
+@pytest.mark.asyncio
+async def test_unleash_registry():
+    async def handler(request: Request):
+        assert request.url.path == "/client/features/clarify"
+        return Response(200, json={"name": "clarify", "variant": {"name": "A"}})
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.AsyncClient(transport=transport)
+    reg = UnleashRegistry("http://unleash", client=client)
+    split = await reg.get_split("clarify", "u1")
+    assert split.experiment_id == "clarify"
+    assert split.variant == "A"
+
+
+@pytest.mark.asyncio
+async def test_growthbook_registry():
+    features = {"clarify": {"id": "clarify", "variants": {"A": 0.5, "B": 0.5}}}
+    reg = GrowthBookRegistry(features)
+    split = await reg.get_split("clarify", "user1")
+    assert split.traffic_split == {"A": 0.5, "B": 0.5}
+    assert split.variant is None
+
+
+@pytest.mark.asyncio
+async def test_engine_sdk_split(tmp_path):
+    """Engine should pick variant using registry weights."""
+    features = {"support_reply": {"id": "clarify", "variants": {"A": 1.0}}}
+    reg = GrowthBookRegistry(features)
+    settings = Setting(template_paths=["./prompts"])
+    engine = PromptEngine.from_setting(settings)
+    class Dummy(ModelClient):
+        provider = "dummy"
+
+        def __init__(self):
+            super().__init__(client=httpx.AsyncClient(http2=False))
+
+        async def _run(self, messages, model_cfg):
+            yield Message(role="assistant", kind="text", content="ok")
+
+    dummy = Dummy()
+    cfg = ModelConfig(provider="dummy", model="x")
+    msgs = engine.run(
+        "support_reply",
+        {"name": "Bob", "issue": "none"},
+        None,
+        model_cfg=cfg,
+        client=dummy,
+        registry=reg,
+    )
+    out = [m async for m in msgs]
+    assert out[-1].content == "ok"

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -1,3 +1,5 @@
+"""Tests for logging and replaying model client responses."""
+
 import json
 import asyncio
 

--- a/tests/test_template_yaml.py
+++ b/tests/test_template_yaml.py
@@ -1,3 +1,5 @@
+"""Tests for YAML-based template loading."""
+
 import pytest
 from prompti.engine import PromptEngine, Setting
 


### PR DESCRIPTION
## Summary
- implement ExperimentSplit.traffic_split field and docstrings
- bucket fallback in PromptEngine.run for SDK split
- update GrowthBook adapter to expose traffic weights
- add more comprehensive experiment tests
- include module docstrings for all test files

## Testing
- `uv pip install --system -e .[test]`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853ecbb887c8320aa3c8ebb6fe9e424