### PR TITLE
Add LiteLLM ModelClient based on litellm package

### DIFF
--- a/prompti/model_client/litellm.py
+++ b/prompti/model_client/litellm.py
@@ -1,15 +1,105 @@
 from __future__ import annotations
 
-"""LiteLLM client implementation."""
+"""LiteLLM client implementation using the ``litellm`` package."""
 
+import json
 import os
+from typing import Any, AsyncGenerator
 
-from .openai_base import _OpenAICore
+import httpx
+
+import litellm
+
+from ..message import Message
+from .base import ModelClient, ModelConfig
 
 
-class LiteLLMClient(_OpenAICore):
-    """Client for a LiteLLM proxy compatible with the OpenAI API."""
+class LiteLLMClient(ModelClient):
+    """Client that delegates LLM calls to ``litellm``."""
 
     provider = "litellm"
-    api_url = os.environ.get("LITELLM_ENDPOINT", "http://localhost:4000/v1/chat/completions")
-    api_key_var = "LITELLM_API_KEY"
+
+    def __init__(self, client: httpx.AsyncClient | None = None) -> None:
+        client = client or httpx.AsyncClient(http2=False)
+        super().__init__(client=client)
+
+    async def _run(
+        self, messages: list[Message], model_cfg: ModelConfig
+    ) -> AsyncGenerator[Message, None]:
+        oa_messages: list[dict[str, Any]] = []
+        for m in messages:
+            role = m.role
+            if m.kind == "tool_result":
+                role = "tool"
+
+            msg: dict[str, Any] = {"role": role}
+
+            if m.kind in ("text", "thinking"):
+                msg["content"] = m.content
+            elif m.kind == "image_url":
+                msg["content"] = [
+                    {"type": "image_url", "image_url": {"url": m.content}}
+                ]
+            elif m.kind == "tool_use":
+                data = m.content if isinstance(m.content, dict) else json.loads(m.content)
+                msg["content"] = None
+                msg["tool_calls"] = [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": data.get("name"),
+                            "arguments": json.dumps(data.get("arguments", {})),
+                        },
+                    }
+                ]
+            elif m.kind == "tool_result":
+                msg["content"] = (
+                    json.dumps(m.content) if not isinstance(m.content, str) else m.content
+                )
+            else:
+                continue
+
+            oa_messages.append(msg)
+
+        payload = {"model": model_cfg.model, "messages": oa_messages}
+        payload.update(model_cfg.parameters)
+        endpoint = os.environ.get("LITELLM_ENDPOINT")
+        api_key = os.environ.get("LITELLM_API_KEY")
+        if endpoint:
+            payload["base_url"] = endpoint
+        if api_key:
+            payload["api_key"] = api_key
+
+        try:
+            resp = await litellm.acompletion(**payload)
+        except Exception as exc:  # pragma: no cover - network errors
+            yield Message(role="assistant", kind="error", content=str(exc))
+            return
+
+        msg = resp.choices[0].message
+        if msg.tool_calls:
+            for call in msg.tool_calls:
+                func = call.function
+                yield Message(
+                    role="assistant",
+                    kind="tool_use",
+                    content=json.dumps(
+                        {
+                            "name": func.name,
+                            "arguments": json.loads(func.arguments or "{}"),
+                        }
+                    ),
+                )
+        elif msg.function_call:
+            func = msg.function_call
+            yield Message(
+                role="assistant",
+                kind="tool_use",
+                content={
+                    "name": func.name,
+                    "arguments": json.loads(func.arguments or "{}"),
+                },
+            )
+        elif msg.content:
+            yield Message(role="assistant", kind="text", content=msg.content)
+

--- a/tests/test_model_client.py
+++ b/tests/test_model_client.py
@@ -6,6 +6,7 @@ import json
 import pytest
 import httpx
 from httpx import Response, Request
+import litellm
 
 from prompti.model_client import (
     ModelConfig,
@@ -18,13 +19,13 @@ from prompti.model_client import (
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "provider,url", [
+    "provider,url",
+    [
         ("openai", "https://api.openai.com/v1/chat/completions"),
         ("openrouter", "https://openrouter.ai/api/v1/chat/completions"),
-        ("litellm", "http://localhost:4000/v1/chat/completions"),
-    ]
+    ],
 )
-async def test_openai_like_providers(provider, url):
+async def test_openai_like_providers(provider: str, url: str):
     async def handler(request: Request):
         assert str(request.url) == url
         return Response(200, json={"choices": [{"message": {"content": "ok"}}]})
@@ -34,11 +35,30 @@ async def test_openai_like_providers(provider, url):
     client_map = {
         "openai": OpenAIClient,
         "openrouter": OpenRouterClient,
-        "litellm": LiteLLMClient,
     }
     mc = client_map[provider](client=client)
     cfg = ModelConfig(provider=provider, model="gpt-4o")
     messages = [Message(role="user", kind="text", content="hi")]
     result = [m async for m in mc.run(messages, cfg)]
     assert result[0].content == "ok"
+
+
+@pytest.mark.asyncio
+async def test_litellm_client(monkeypatch):
+    captured = {}
+
+    async def fake_acompletion(**kwargs):
+        captured["kwargs"] = kwargs
+        return litellm.ModelResponse(choices=[{"message": {"content": "ok"}}])
+
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
+
+    mc = LiteLLMClient()
+    cfg = ModelConfig(provider="litellm", model="gpt-3.5")
+    messages = [Message(role="user", kind="text", content="hi")]
+    result = [m async for m in mc.run(messages, cfg)]
+
+    assert result[0].content == "ok"
+    assert captured["kwargs"]["model"] == "gpt-3.5"
+    assert captured["kwargs"]["messages"][0]["content"] == "hi"
 


### PR DESCRIPTION
## Summary
- implement LiteLLMClient using litellm to route requests
- add tests for LiteLLMClient and adjust existing client tests

## Testing
- `pip install -e .[test]`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685506b4b16883209385e69b58060bd2