### PR TITLE
Fix Rust client build and CLI

### DIFF
--- a/prompti/model_client_rs/src/error.rs
+++ b/prompti/model_client_rs/src/error.rs
@@ -104,6 +104,8 @@ impl std::fmt::Display for EnvVarError {
     }
 }
 
+impl std::error::Error for EnvVarError {}
+
 impl ModelError {
     /// Check if the error is retryable
     pub fn is_retryable(&self) -> bool {

--- a/prompti/model_client_rs/src/main.rs
+++ b/prompti/model_client_rs/src/main.rs
@@ -1,6 +1,6 @@
-use clap::{App, Arg};
-use model_client_rs::{ModelClient, config::{ClientConfig, ProviderConfig}};
-use model_client_rs::models::{ChatMessage, ChatRequest};
+use clap::{Arg, ArgAction, Command};
+use model_client_rs::{ModelClient, config::{ClientConfig, ProviderConfig, ModelConfig}};
+use model_client_rs::models::{ChatMessage, ChatRequest, MessageRole};
 use serde_json;
 use std::fs;
 use std::io::{self, Write};
@@ -9,7 +9,7 @@ use futures::StreamExt;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let matches = App::new("model-client-rs")
+    let matches = Command::new("model-client-rs")
         .version("0.1.0")
         .about("Rust-based model client for LLM providers")
         .arg(
@@ -18,23 +18,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .value_name("FILE")
                 .help("JSON file containing the request")
                 .required(true)
+                .action(ArgAction::Set)
         )
         .arg(
             Arg::new("stream")
                 .long("stream")
                 .help("Enable streaming output")
-                .takes_value(false)
+                .action(ArgAction::SetTrue)
         )
         .get_matches();
 
     // Read request from file
-    let request_file = matches.value_of("request-file").unwrap();
+    let request_file: &String = matches.get_one("request-file").expect("required");
     let request_data: serde_json::Value = serde_json::from_str(&fs::read_to_string(request_file)?)?;
     
     // Extract configuration
     let provider = request_data["provider"].as_str().unwrap_or("openai");
     let model = request_data["model"].as_str().unwrap_or("gpt-3.5-turbo");
-    let parameters = request_data["parameters"].as_object().unwrap_or(&serde_json::Map::new());
+    let parameters = request_data["parameters"].as_object().cloned().unwrap_or_default();
     
     // Get API key from environment
     let api_key = match provider {
@@ -45,15 +46,29 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     
     // Create client configuration
     let provider_config = ProviderConfig {
-        id: provider.to_string(),
+        id: provider.into(),
         api_key: Some(api_key.clone()),
-        api_base: parameters.get("api_base").and_then(|v| v.as_str()).map(|s| s.to_string()),
+        api_base: parameters
+            .get("api_base")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
     };
-    
+
+    let model_config = ModelConfig {
+        id: model.into(),
+        temperature: None,
+        max_tokens: None,
+        top_p: None,
+        n: None,
+        stop: None,
+    };
+
     let client_config = ClientConfig {
+        provider: provider_config,
+        model: model_config,
         api_key: Some(api_key),
         api_base: None,
-        provider: provider_config,
+        timeout_secs: None,
     };
     
     // Create model client
@@ -65,38 +80,50 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .unwrap_or(&Vec::new())
         .iter()
         .map(|msg| {
+            let role_str = msg["role"].as_str().unwrap_or("user");
+            let role = match role_str {
+                "system" => MessageRole::System,
+                "assistant" => MessageRole::Assistant,
+                "tool" => MessageRole::Tool,
+                _ => MessageRole::User,
+            };
             ChatMessage {
-                role: msg["role"].as_str().unwrap_or("user").to_string(),
+                role,
                 content: msg["content"].as_str().unwrap_or("").to_string(),
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
             }
         })
         .collect();
     
     // Create chat request
-    let chat_request = ChatRequest {
-        messages,
-        model: model.to_string(),
-        temperature: parameters.get("temperature").and_then(|v| v.as_f64()).unwrap_or(0.7),
-        max_tokens: parameters.get("max_tokens").and_then(|v| v.as_u64()).map(|v| v as u32),
-        stream: matches.is_present("stream"),
-        ..Default::default()
-    };
+    let mut chat_request = ChatRequest::new(model.to_string(), messages);
+    if let Some(temp) = parameters.get("temperature").and_then(|v| v.as_f64()) {
+        chat_request = chat_request.with_temperature(temp as f32);
+    }
+    if let Some(max) = parameters.get("max_tokens").and_then(|v| v.as_u64()) {
+        chat_request = chat_request.with_max_tokens(max as u32);
+    }
+    chat_request = chat_request.with_stream(matches.get_flag("stream"));
     
     // Execute request
-    if matches.is_present("stream") {
+    if matches.get_flag("stream") {
         // Streaming response
         let mut stream = client.chat_stream(&chat_request).await?;
         
         while let Some(result) = stream.next().await {
             match result {
                 Ok(response) => {
-                    if let Some(content) = response.content {
-                        let output = serde_json::json!({
-                            "content": content,
-                            "role": "assistant"
-                        });
-                        println!("{}", serde_json::to_string(&output)?);
-                        io::stdout().flush()?;
+                    if let Some(choice) = response.choices.first() {
+                        if let Some(delta) = &choice.delta {
+                            let output = serde_json::json!({
+                                "content": delta.content,
+                                "role": "assistant"
+                            });
+                            println!("{}", serde_json::to_string(&output)?);
+                            io::stdout().flush()?;
+                        }
                     }
                 }
                 Err(e) => {
@@ -108,7 +135,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     } else {
         // Non-streaming response
         let response = client.chat(&chat_request).await?;
-        if let Some(content) = response.content {
+        if let Some(content) = response.get_content() {
             let output = serde_json::json!({
                 "content": content,
                 "role": "assistant"

--- a/prompti/model_client_rs/src/utils.rs
+++ b/prompti/model_client_rs/src/utils.rs
@@ -5,12 +5,12 @@ use serde_json::Value;
 
 /// Parse a JSON string into a Value
 pub fn parse_json(json_str: &str) -> ModelResult<Value> {
-    serde_json::from_str(json_str).map_err(|e| crate::error::ModelError::Serialization(e.to_string()))
+    serde_json::from_str(json_str).map_err(Into::into)
 }
 
 /// Convert a Value to a JSON string
 pub fn to_json(value: &Value) -> ModelResult<String> {
-    serde_json::to_string(value).map_err(|e| crate::error::ModelError::Serialization(e.to_string()))
+    serde_json::to_string(value).map_err(Into::into)
 }
 
 /// Extract a string value from a JSON object


### PR DESCRIPTION
## Summary
- ensure `model_client_rs` library builds
- update CLI code to match current structs and clap API
- handle JSON helpers without custom error variant
- implement `std::error::Error` for `EnvVarError`

## Testing
- `cargo build --release --lib`
- `cargo build --release`
- `python -m py_compile prompti/model_client/rust.py`
- `pytest -k rust -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68552e0565ec83209ff2bf171fd93283