### PR TITLE
Allow passing API details when creating OpenAI clients

### DIFF
--- a/prompti/model_client/base.py
+++ b/prompti/model_client/base.py
@@ -37,8 +37,12 @@ class ModelClient:
         "llm_request_latency_seconds", "LLM latency", labelnames=["provider"]
     )
 
-    def __init__(self, client: httpx.AsyncClient | None = None) -> None:
-        """Create the client with an optional :class:`httpx.AsyncClient`."""
+    def __init__(self, client: httpx.AsyncClient | None = None, **_: Any) -> None:
+        """Create the client with an optional :class:`httpx.AsyncClient`.
+
+        ``**_`` allows subclasses to accept additional parameters without
+        changing this base signature.
+        """
         self._client = client or httpx.AsyncClient(http2=True)
         self._tracer = trace.get_tracer(__name__)
 

--- a/tests/test_engine_tools.py
+++ b/tests/test_engine_tools.py
@@ -14,8 +14,7 @@ async def test_engine_with_tools():
     with OpenAIMockServer("tests/data/openai_record.jsonl") as url:
         os.environ["OPENAI_API_KEY"] = "testkey"
         engine = PromptEngine.from_setting(Setting(template_paths=[Path("./prompts")]))
-        client = OpenAIClient(client=httpx.AsyncClient())
-        client.api_url = url  # type: ignore
+        client = OpenAIClient(client=httpx.AsyncClient(), api_url=url)
         cfg = ModelConfig(provider="openai", model="gpt-3.5-turbo")
 
         tools = [

--- a/tests/test_model_client.py
+++ b/tests/test_model_client.py
@@ -38,12 +38,7 @@ async def test_openai_like_providers(provider):
             "openai": OpenAIClient,
             "openrouter": OpenRouterClient,
         }
-        mc = client_map[provider](client=httpx.AsyncClient())
-        if provider == "openai":
-            mc.api_url = url  # type: ignore
-        else:
-            # For OpenRouter, we need to set the base URL
-            mc.api_url = url  # type: ignore
+        mc = client_map[provider](client=httpx.AsyncClient(), api_url=url)
 
         cfg = ModelConfig(provider=provider, model="gpt-3.5-turbo")
         messages = [Message(role="user", kind="text", content="hello")]
@@ -55,8 +50,7 @@ async def test_openai_like_providers(provider):
 async def test_model_client_tools():
     with OpenAIMockServer("tests/data/openai_record.jsonl") as url:
         os.environ["OPENAI_API_KEY"] = "testkey"
-        mc = OpenAIClient(client=httpx.AsyncClient())
-        mc.api_url = url  # type: ignore
+        mc = OpenAIClient(client=httpx.AsyncClient(), api_url=url)
         cfg = ModelConfig(provider="openai", model="gpt-3.5-turbo")
         messages = [Message(role="user", kind="text", content="What time is it?")]
 
@@ -71,8 +65,7 @@ async def test_model_client_tools():
 async def test_model_client_tool_request_format():
     with OpenAIMockServer("tests/data/openai_record.jsonl") as url:
         os.environ["OPENAI_API_KEY"] = "testkey"
-        mc = OpenAIClient(client=httpx.AsyncClient())
-        mc.api_url = url  # type: ignore
+        mc = OpenAIClient(client=httpx.AsyncClient(), api_url=url)
         cfg = ModelConfig(provider="openai", model="gpt-3.5-turbo")
         messages = [Message(role="user", kind="text", content="What time is it?")]
 

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -12,8 +12,7 @@ from prompti.model_client import Message, ModelConfig, OpenAIClient
 async def test_openai_client():
     with OpenAIMockServer("tests/data/openai_record.jsonl") as url:
         os.environ["OPENAI_API_KEY"] = "testkey"
-        client = OpenAIClient(client=httpx.AsyncClient())
-        client.api_url = url  # type: ignore
+        client = OpenAIClient(client=httpx.AsyncClient(), api_url=url)
 
         cfg = ModelConfig(provider="openai", model="gpt-3.5-turbo")
         messages = [Message(role="user", kind="text", content="hello")]

--- a/tests/test_rust_client.py
+++ b/tests/test_rust_client.py
@@ -47,8 +47,7 @@ async def test_rust_client_with_openai_fallback():
         os.environ["OPENAI_API_KEY"] = "testkey"
 
         # Test the actual OpenAI client that the Rust client might fall back to
-        openai_client = OpenAIClient(client=httpx.AsyncClient())
-        openai_client.api_url = url  # type: ignore
+        openai_client = OpenAIClient(client=httpx.AsyncClient(), api_url=url)
 
         messages = [Message(role="user", content="hello", kind="text")]
         model_cfg = ModelConfig(


### PR DESCRIPTION
## Summary
- let `ModelClient.__init__` accept `**kwargs`
- add `__init__` to `_OpenAICore` to allow specifying `api_url`, `api_key_var`, and `api_key`
- read explicit API key in `_OpenAICore._run`
- update tests to construct OpenAI clients with the new arguments

## Testing
- `ruff check .`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685678e4acec8320b3172b3ca9770389