### PR TITLE
Refactor PromptTemplate to parse YAML at runtime

### DIFF
--- a/prompti/engine.py
+++ b/prompti/engine.py
@@ -49,7 +49,7 @@ class FileSystemLoader:
             version=version,
             labels=list(data.get("labels", [])),
             required_variables=list(data.get("required_variables", [])),
-            messages=data.get("messages", []),
+            yaml=text,
         )
         return version, tmpl
 

--- a/prompti/loaders.py
+++ b/prompti/loaders.py
@@ -29,7 +29,7 @@ class MemoryLoader:
             version=version,
             labels=list(ydata.get("labels", [])),
             required_variables=list(ydata.get("required_variables", [])),
-            messages=ydata.get("messages", []),
+            yaml=text,
         )
         return version, tmpl
 
@@ -58,6 +58,6 @@ class HTTPLoader:
             version=version,
             labels=list(ydata.get("labels", [])),
             required_variables=list(ydata.get("required_variables", [])),
-            messages=ydata.get("messages", []),
+            yaml=text,
         )
         return version, tmpl

--- a/prompti/template.py
+++ b/prompti/template.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import AsyncGenerator
 from typing import Any
 
+import yaml
 from jinja2 import StrictUndefined
 from jinja2.sandbox import SandboxedEnvironment
 from pydantic import BaseModel
@@ -23,7 +24,7 @@ class PromptTemplate(BaseModel):
     version: str
     labels: list[str] = []
     required_variables: list[str] = []
-    messages: list[dict]
+    yaml: str = ""
 
     def format(
         self,
@@ -34,8 +35,11 @@ class PromptTemplate(BaseModel):
         if missing:
             raise KeyError(f"missing variables: {missing}")
 
+        ydata = yaml.safe_load(self.yaml) if self.yaml else {}
+        messages = ydata.get("messages", [])
+
         results: list[Message] = []
-        for msg in self.messages:
+        for msg in messages:
             role = msg.get("role")
             for part in msg.get("parts", []):
                 ptype = part.get("type")

--- a/tests/claude_mock_server.py
+++ b/tests/claude_mock_server.py
@@ -4,10 +4,11 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import Any
 
+
 class ClaudeMockServer:
     def __init__(self, log_path: str | Path, host: str = "127.0.0.1", port: int = 0):
         self._log = []
-        with open(log_path, "r", encoding="utf-8") as f:
+        with open(log_path, encoding="utf-8") as f:
             for line in f:
                 self._log.append(json.loads(line))
         self.host = host

--- a/tests/test_claude_client.py
+++ b/tests/test_claude_client.py
@@ -1,11 +1,12 @@
-import json
 import os
-import pytest
-import httpx
 
-from prompti.model_client import ModelConfig, ClaudeClient
-from prompti import Message
+import httpx
+import pytest
 from claude_mock_server import ClaudeMockServer
+
+from prompti import Message
+from prompti.model_client import ClaudeClient, ModelConfig
+
 
 @pytest.mark.asyncio
 async def test_claude_client():

--- a/tests/test_template_yaml.py
+++ b/tests/test_template_yaml.py
@@ -26,17 +26,13 @@ class TestPromptTemplateFormat:
             name="test",
             version="1.0",
             required_variables=["name"],
-            messages=[
-                {
-                    "role": "user",
-                    "parts": [
-                        {
-                            "type": "text",
-                            "text": "Hello {{ name }}!"
-                        }
-                    ]
-                }
-            ]
+            yaml="""
+messages:
+  - role: user
+    parts:
+      - type: text
+        text: "Hello {{ name }}!"
+""",
         )
 
         messages = template.format({"name": "World"})
@@ -53,35 +49,21 @@ class TestPromptTemplateFormat:
             name="test",
             version="1.0",
             required_variables=["topic", "details"],
-            messages=[
-                {
-                    "role": "system",
-                    "parts": [
-                        {
-                            "type": "text",
-                            "text": "You are an expert on {{ topic }}."
-                        }
-                    ]
-                },
-                {
-                    "role": "user",
-                    "parts": [
-                        {
-                            "type": "text",
-                            "text": "Please explain {{ details }}."
-                        }
-                    ]
-                },
-                {
-                    "role": "assistant",
-                    "parts": [
-                        {
-                            "type": "text",
-                            "text": "I'll help you understand {{ topic }} and {{ details }}."
-                        }
-                    ]
-                }
-            ]
+            yaml="""
+messages:
+  - role: system
+    parts:
+      - type: text
+        text: "You are an expert on {{ topic }}."
+  - role: user
+    parts:
+      - type: text
+        text: "Please explain {{ details }}."
+  - role: assistant
+    parts:
+      - type: text
+        text: "I'll help you understand {{ topic }} and {{ details }}."
+""",
         )
 
         messages = template.format({"topic": "AI", "details": "neural networks"})
@@ -100,21 +82,15 @@ class TestPromptTemplateFormat:
             id="test",
             name="test",
             version="1.0",
-            messages=[
-                {
-                    "role": "user",
-                    "parts": [
-                        {
-                            "type": "text",
-                            "text": "Please analyze this file:"
-                        },
-                        {
-                            "type": "file",
-                            "file": "/path/to/document.pdf"
-                        }
-                    ]
-                }
-            ]
+            yaml="""
+messages:
+  - role: user
+    parts:
+      - type: text
+        text: "Please analyze this file:"
+      - type: file
+        file: "/path/to/document.pdf"
+""",
         )
 
         messages = template.format({})
@@ -134,22 +110,13 @@ class TestPromptTemplateFormat:
             name="test",
             version="1.0",
             required_variables=["items"],
-            messages=[
-                {
-                    "role": "user",
-                    "parts": [
-                        {
-                            "type": "text",
-                            "text": (
-                                "Here are the items:\n"
-                                "{% for item in items %}"
-                                "{{ loop.index }}. {{ item }}\n"
-                                "{% endfor %}"
-                            ),
-                        }
-                    ],
-                }
-            ],
+            yaml="""
+messages:
+  - role: user
+    parts:
+      - type: text
+        text: "Here are the items:\n{% for item in items %}{{ loop.index }}. {{ item }}\n{% endfor %}"
+""",
         )
 
         messages = template.format({"items": ["apple", "banana", "cherry"]})
@@ -164,21 +131,18 @@ class TestPromptTemplateFormat:
             name="test",
             version="1.0",
             required_variables=["user_type", "name"],
-            messages=[
-                {
-                    "role": "assistant",
-                    "parts": [
-                        {
-                            "type": "text",
-                            "text": (
-                                "{% if user_type == 'premium' %}Welcome back, premium member {{ name }}! "
-                                "You have access to all features.{% else %}Hello {{ name }}! "
-                                "Consider upgrading to premium for more features.{% endif %}"
-                            ),
-                        }
-                    ],
-                }
-            ],
+            yaml="""
+messages:
+  - role: assistant
+    parts:
+      - type: text
+        text: |
+          {% if user_type == 'premium' %}
+          Welcome back, premium member {{ name }}! You have access to all features.
+          {% else %}
+          Hello {{ name }}! Consider upgrading to premium for more features.
+          {% endif %}
+""",
         )
 
         # Test premium user
@@ -196,27 +160,24 @@ class TestPromptTemplateFormat:
             name="test",
             version="1.0",
             required_variables=["tasks", "priority_threshold"],
-            messages=[
-                {
-                    "role": "user",
-                    "parts": [
-                        {
-                            "type": "text",
-                            "text": """Task Report:
-{% for task in tasks -%}
-{% if task.priority >= priority_threshold -%}
-🔥 HIGH: {{ task.name }} (Priority: {{ task.priority }})
-{% else -%}
-📝 NORMAL: {{ task.name }} (Priority: {{ task.priority }})
-{% endif -%}
-{% endfor -%}
+            yaml="""
+messages:
+  - role: user
+    parts:
+      - type: text
+        text: |
+          Task Report:
+          {% for task in tasks -%}
+          {% if task.priority >= priority_threshold -%}
+          🔥 HIGH: {{ task.name }} (Priority: {{ task.priority }})
+          {% else -%}
+          📝 NORMAL: {{ task.name }} (Priority: {{ task.priority }})
+          {% endif -%}
+          {% endfor -%}
 
-{% set high_priority_count = tasks | selectattr('priority', '>=', priority_threshold) | list | length -%}
-Total high-priority tasks: {{ high_priority_count }}"""
-                        }
-                    ]
-                }
-            ]
+          {% set high_priority_count = tasks | selectattr('priority', '>=', priority_threshold) | list | length -%}
+          Total high-priority tasks: {{ high_priority_count }}
+""",
         )
 
         tasks_data = {
@@ -245,20 +206,16 @@ Total high-priority tasks: {{ high_priority_count }}"""
             name="test",
             version="1.0",
             required_variables=["name", "age"],
-            messages=[
-                {
-                    "role": "user",
-                    "parts": [
-                        {
-                            "type": "text",
-                            "text": "Hello {{ name }}, you are {{ age }} years old."
-                        }
-                    ]
-                }
-            ]
+            yaml="""
+messages:
+  - role: user
+    parts:
+      - type: text
+        text: "Hello {{ name }}, you are {{ age }} years old."
+""",
         )
 
-        with pytest.raises(KeyError, match="missing variables: \\['age'\\]"):
+        with pytest.raises(KeyError, match=r"missing variables: \['age'\]"):
             template.format({"name": "Alice"})
 
     def test_format_empty_template(self):
@@ -267,7 +224,9 @@ Total high-priority tasks: {{ high_priority_count }}"""
             id="test",
             name="test",
             version="1.0",
-            messages=[]
+            yaml="""
+messages: []
+""",
         )
 
         messages = template.format({})
@@ -279,17 +238,13 @@ Total high-priority tasks: {{ high_priority_count }}"""
             id="test",
             name="test",
             version="1.0",
-            messages=[
-                {
-                    "role": "user",
-                    "parts": [
-                        {
-                            "type": "text",
-                            "text": "Hello world"
-                        }
-                    ]
-                }
-            ]
+            yaml="""
+messages:
+  - role: user
+    parts:
+      - type: text
+        text: "Hello world"
+""",
         )
 
         # Should not raise an error
@@ -304,24 +259,21 @@ Total high-priority tasks: {{ high_priority_count }}"""
             name="test",
             version="1.0",
             required_variables=["project_name", "features"],
-            messages=[
-                {
-                    "role": "system",
-                    "parts": [
-                        {
-                            "type": "text",
-                            "text": """You are a technical writer for {{ project_name }}.
+            yaml="""
+messages:
+  - role: system
+    parts:
+      - type: text
+        text: |
+          You are a technical writer for {{ project_name }}.
 
-Please create documentation that covers:
-{% for feature in features -%}
-- {{ feature }}
-{% endfor %}
+          Please create documentation that covers:
+          {% for feature in features -%}
+          - {{ feature }}
+          {% endfor %}
 
-Make it clear and comprehensive."""
-                        }
-                    ]
-                }
-            ]
+          Make it clear and comprehensive.
+""",
         )
 
         messages = template.format({


### PR DESCRIPTION
## Summary
- refactor `PromptTemplate` to store raw YAML instead of parsed messages
- adapt file system and other loaders to pass YAML source
- regenerate test suite using YAML definitions
- run `ruff` to format imports

## Testing
- `ruff check --fix prompti/template.py tests/test_template_yaml.py tests/claude_mock_server.py tests/test_claude_client.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685675cb6cd483208c04a422319313a6