### PR TITLE
Support override of ClaudeClient API details

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ key environment variables such as `OPENAI_API_KEY` before running examples.
 | Client            | Environment variables                        | Notes                              |
 | ----------------- | -------------------------------------------- | ---------------------------------- |
 | `OpenAIClient`    | `OPENAI_API_KEY`, optional `OPENAI_API_BASE` | Uses OpenAI chat completions.       |
-| `ClaudeClient`    | `ANTHROPIC_API_KEY`                          | Supports thinking, tool use, image |
+| `ClaudeClient`    | `ANTHROPIC_API_KEY`                          | Supports thinking, tool use, image. Accepts custom `api_url`, `api_key_var`, `api_key` |
 | `LiteLLMClient`   | `LITELLM_API_KEY`, `LITELLM_ENDPOINT`        | Routes through `litellm.acompletion` |
 | `RustModelClient` | n/a (reads from `ModelConfig.api_key`)       | Calls an external Rust binary.     |
 


### PR DESCRIPTION
## Summary
- allow overriding api_url, api_key_var, and api_key when constructing `ClaudeClient`
- use provided api key or value from `ModelConfig`
- document the new options in README
- update Claude tests for new initializer

## Testing
- `ruff check .`
- `PYTHONPATH=. pytest -q` *(fails: test_template_yaml::TestPromptTemplateFormat::test_format_jinja2_for_loop, test_template_yaml::TestPromptTemplateFormat::test_format_jinja2_if_else)*

------
https://chatgpt.com/codex/tasks/task_e_68567f5736288320a434460007ae44e6