### PR TITLE
Add Kind enum

### DIFF
--- a/prompti/__init__.py
+++ b/prompti/__init__.py
@@ -8,7 +8,7 @@ from .experiment import (
     UnleashRegistry,
     bucket,
 )
-from .message import Message
+from .message import Message, Kind
 from .model_client import (
     ClaudeClient,
     LiteLLMClient,
@@ -37,4 +37,5 @@ __all__ = [
     "UnleashRegistry",
     "GrowthBookRegistry",
     "bucket",
+    "Kind",
 ]

--- a/prompti/message.py
+++ b/prompti/message.py
@@ -3,8 +3,17 @@
 from __future__ import annotations
 
 from typing import Any
+from enum import Enum
 
 from pydantic import BaseModel
+
+
+class Kind(str, Enum):
+    """Valid message part kinds from the A2A specification."""
+
+    TEXT = "text"
+    FILE = "file"
+    DATA = "data"
 
 
 class Message(BaseModel):


### PR DESCRIPTION
## Summary
- add `Kind` enumeration to message module
- expose enum from package init

## Testing
- `python -m pytest -q` *(fails: 2 failed, 27 passed)*

------
https://chatgpt.com/codex/tasks/task_e_685680756d5c8320b639620c1d6d2828