### PR TITLE
Add loaders for popular prompt CMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,39 @@ interface with built-in **Unleash** and **GrowthBook** adapters.
 
 See `DESIGN.md` for a more detailed description of the architecture.
 
+## 🔌 Template Loaders
+
+Prompti can read prompt templates from multiple back-ends. In addition to local
+files, you can load templates from PromptLayer, Langfuse, Pezzo, Agenta, GitHub
+repositories, or a local Git repo. Each loader exposes the same async call
+contract:
+
+```python
+version, tmpl = await loader("my_prompt", label="prod")
+```
+
+To wire them up:
+
+```python
+from prompti.loader import (
+    PromptLayerLoader,
+    LangfuseLoader,
+    PezzoLoader,
+    AgentaLoader,
+    GitHubRepoLoader,
+    LocalGitRepoLoader,
+)
+
+loaders = {
+    "promptlayer": PromptLayerLoader(api_key="pl-key"),
+    "langfuse": LangfuseLoader(public_key="pk", secret_key="sk"),
+    "pezzo": PezzoLoader(project="my-project"),
+    "agenta": AgentaLoader(app_slug="my-app"),
+    "github": GitHubRepoLoader(repo="org/repo"),
+    "git": LocalGitRepoLoader(Path("/opt/prompts")),
+}
+```
+
 ## 💬 A2A Message Format
 
 Messages consist of an array of parts. The three common part shapes are:

--- a/prompti/__init__.py
+++ b/prompti/__init__.py
@@ -8,6 +8,17 @@ from .experiment import (
     UnleashRegistry,
     bucket,
 )
+from .loader import (
+    AgentaLoader,
+    FileSystemLoader,
+    GitHubRepoLoader,
+    HTTPLoader,
+    LangfuseLoader,
+    LocalGitRepoLoader,
+    MemoryLoader,
+    PezzoLoader,
+    PromptLayerLoader,
+)
 from .message import Kind, Message
 from .model_client import (
     ClaudeClient,
@@ -48,4 +59,13 @@ __all__ = [
     "GrowthBookRegistry",
     "bucket",
     "Kind",
+    "HTTPLoader",
+    "FileSystemLoader",
+    "MemoryLoader",
+    "PromptLayerLoader",
+    "LangfuseLoader",
+    "PezzoLoader",
+    "AgentaLoader",
+    "GitHubRepoLoader",
+    "LocalGitRepoLoader",
 ]

--- a/prompti/loader.py
+++ b/prompti/loader.py
@@ -87,3 +87,168 @@ class HTTPLoader:
             yaml=text,
         )
         return version, tmpl
+
+
+class PromptLayerLoader:
+    """Load templates from PromptLayer."""
+
+    URL = "https://api.promptlayer.com/prompt-templates"
+
+    def __init__(self, api_key: str, client: httpx.AsyncClient | None = None) -> None:
+        self.api_key = api_key
+        self.client = client or httpx.AsyncClient()
+
+    async def __call__(self, name: str, label: str | None) -> tuple[str, PromptTemplate]:
+        body = {"label": label} if label else {}
+        resp = await self.client.post(
+            f"{self.URL}/{name}",
+            headers={"X-API-KEY": self.api_key, "Content-Type": "application/json"},
+            json=body,
+        )
+        if resp.status_code != 200:
+            raise FileNotFoundError(name)
+        data = resp.json()
+        content = data["prompt_template"]["content"]
+        yaml_blob = yaml.safe_dump({"messages": content})
+        tmpl = PromptTemplate(
+            id=name,
+            name=name,
+            version=str(data["version"]),
+            labels=[label] if label else [],
+            yaml=yaml_blob,
+        )
+        return tmpl.version, tmpl
+
+
+class LangfuseLoader:
+    """Load templates via the Langfuse SDK."""
+
+    def __init__(
+        self,
+        public_key: str,
+        secret_key: str,
+        base_url: str = "https://cloud.langfuse.com",
+    ) -> None:
+        from langfuse import get_client
+
+        self.client = get_client(public_key=public_key, secret_key=secret_key, base_url=base_url)
+
+    async def __call__(self, name: str, label: str | None) -> tuple[str, PromptTemplate]:
+        prm = await asyncio.to_thread(self.client.prompts().get_prompt, name, label=label)
+        yaml_blob = prm.yaml
+        meta = yaml.safe_load(yaml_blob)
+        tmpl = PromptTemplate(
+            id=name,
+            name=name,
+            version=str(prm.version),
+            labels=prm.labels,
+            yaml=yaml_blob,
+            required_variables=meta.get("required_variables", []),
+        )
+        return tmpl.version, tmpl
+
+
+class PezzoLoader:
+    """Retrieve prompts via the Pezzo client."""
+
+    def __init__(self, project: str) -> None:
+        from pezzo import PezzoClient
+
+        self.client = PezzoClient(project=project)
+
+    async def __call__(self, name: str, label: str | None) -> tuple[str, PromptTemplate]:
+        prompt = await self.client.get_prompt(slug=name, environment="production", version_tag=label)
+        yaml_blob = prompt["yaml"]
+        meta = yaml.safe_load(yaml_blob)
+        tmpl = PromptTemplate(
+            id=name,
+            name=name,
+            version=str(prompt["version"]),
+            labels=meta.get("labels", prompt.get("tags", [])),
+            yaml=yaml_blob,
+        )
+        return tmpl.version, tmpl
+
+
+class AgentaLoader:
+    """Fetch templates from Agenta via the SDK."""
+
+    def __init__(self, app_slug: str) -> None:
+        import agenta as ag
+
+        ag.init()
+        self.app_slug = app_slug
+
+    async def __call__(self, name: str, label: str | None) -> tuple[str, PromptTemplate]:
+        cfg = await asyncio.to_thread(
+            ag.ConfigManager.get_from_registry,
+            app_slug=self.app_slug,
+            variant_slug=name,
+            environment_slug=label or "production",
+        )
+        yaml_blob = yaml.safe_dump(cfg["prompt"])
+        tmpl = PromptTemplate(
+            id=name,
+            name=name,
+            version=str(cfg.get("variant_version", "0")),
+            labels=[label] if label else ["production"],
+            yaml=yaml_blob,
+        )
+        return tmpl.version, tmpl
+
+
+class GitHubRepoLoader:
+    """Fetch prompt files from a GitHub repository."""
+
+    def __init__(self, repo: str, branch: str = "main", token: str | None = None, root: str = "prompts") -> None:
+        self.repo = repo
+        self.branch = branch
+        self.root = root
+        self.headers = {"Authorization": f"token {token}"} if token else {}
+        self.client = httpx.AsyncClient()
+
+    async def __call__(self, name: str, label: str | None) -> tuple[str, PromptTemplate]:
+        path = f"{self.root}/{name}.yaml"
+        url = f"https://api.github.com/repos/{self.repo}/contents/{path}"
+        resp = await self.client.get(url, params={"ref": self.branch}, headers=self.headers)
+        if resp.status_code != 200:
+            raise FileNotFoundError(name)
+        data = resp.json()
+        import base64
+        import codecs
+
+        text = codecs.decode(base64.b64decode(data["content"]), "utf-8")
+        meta = yaml.safe_load(text)
+        tmpl = PromptTemplate(
+            id=name,
+            name=name,
+            version=self.branch,
+            labels=meta.get("labels", []),
+            yaml=text,
+        )
+        return tmpl.version, tmpl
+
+
+class LocalGitRepoLoader:
+    """Read prompt files from a local Git repository."""
+
+    def __init__(self, repo_path: Path, ref: str = "HEAD") -> None:
+        import pygit2
+
+        self.repo = pygit2.Repository(str(repo_path))
+        self.ref = ref
+
+    async def __call__(self, name: str, label: str | None) -> tuple[str, PromptTemplate]:
+        commit = self.repo.revparse_single(self.ref)
+        tree = commit.tree
+        blob = tree[f"prompts/{name}.yaml"]
+        text = blob.data.decode()
+        meta = yaml.safe_load(text)
+        tmpl = PromptTemplate(
+            id=name,
+            name=name,
+            version=str(commit.hex[:7]),
+            labels=meta.get("labels", []),
+            yaml=text,
+        )
+        return tmpl.version, tmpl


### PR DESCRIPTION
## Summary
- implement PromptLayer, Langfuse, Pezzo, Agenta, GitHubRepo, and LocalGitRepo loaders
- export new loaders from package
- document available loaders in README

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68576a8ee6b483209c3792bdbfcbb884