### PR TITLE
Drop unused ModelConfig parameter

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -43,7 +43,6 @@ class PromptTemplate(BaseModel):
         self,
         variables: dict,
         tag: str | None,
-        model_cfg: ModelConfig,
         *,
         tool_params: ToolParams | list[ToolSpec] | list[dict] | None = None,
     ) -> AsyncGenerator[Message, None]: ...
@@ -57,7 +56,7 @@ class PromptTemplate(BaseModel):
 ```python
 class PromptEngine:
     async def format(self, name: str, variables: dict, tags: str | None = None) -> list[Message]: ...
-    async def run(self, name: str, variables: dict, tags: str | None, model_cfg: ModelConfig, *, tool_params: ToolParams | list[ToolSpec] | list[dict] | None = None) -> AsyncGenerator[Message, None]: ...
+    async def run(self, name: str, variables: dict, tags: str | None, client: ModelClient, *, tool_params: ToolParams | list[ToolSpec] | list[dict] | None = None) -> AsyncGenerator[Message, None]: ...
 ```
 
 * 多种 `TemplateLoader`（FS / HTTP / Memory）+ `async-lru` TTL 缓存。

--- a/README.md
+++ b/README.md
@@ -217,7 +217,6 @@ async def main():
         "support_reply",
         {"name": "Ada", "issue": "login failed"},
         None,
-        model_cfg=cfg,
         client=create_client(cfg),
         registry=reg,
     ):

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -36,7 +36,6 @@ async def main():
         "support_reply",
         {"name": "Ada", "issue": "login failed"},
         tags=None,
-        model_cfg=model_cfg,
         client=client,
         stream=True,
     ):

--- a/prompti/engine.py
+++ b/prompti/engine.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel
 from .experiment import ExperimentRegistry, bucket
 from .loader import FileSystemLoader, HTTPLoader, MemoryLoader
 from .message import Message
-from .model_client import ModelClient, ModelConfig, ToolParams, ToolSpec
+from .model_client import ModelClient, ToolParams, ToolSpec
 from .template import PromptTemplate
 
 _tracer = trace.get_tracer(__name__)
@@ -53,7 +53,6 @@ class PromptEngine:
         template_name: str,
         variables: dict[str, Any],
         tags: str | None,
-        model_cfg: ModelConfig,
         client: ModelClient,
         *,
         headers: dict[str, str] | None = None,
@@ -97,7 +96,6 @@ class PromptEngine:
             async for msg in tmpl.run(
                 variables,
                 tag,
-                model_cfg,
                 client=client,
                 tool_params=tool_params,
                 **run_params,

--- a/prompti/template.py
+++ b/prompti/template.py
@@ -15,7 +15,6 @@ from pydantic import BaseModel, PrivateAttr
 from .message import Kind, Message
 from .model_client import (
     ModelClient,
-    ModelConfig,
     RunParams,
     ToolParams,
     ToolSpec,
@@ -80,7 +79,6 @@ class PromptTemplate(BaseModel):
         self,
         variables: dict[str, Any],
         tag: str | None,
-        model_cfg: ModelConfig,
         client: ModelClient,
         *,
         tool_params: ToolParams | list[ToolSpec] | list[dict] | None = None,

--- a/tests/test_engine_tools.py
+++ b/tests/test_engine_tools.py
@@ -37,7 +37,6 @@ async def test_engine_with_tools():
                 "support_reply",
                 {"name": "Bob", "issue": "none"},
                 None,
-                model_cfg=cfg,
                 client=client,
                 tool_params=tools,
                 stream=False,

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -67,7 +67,6 @@ async def test_engine_sdk_split(tmp_path):
         "support_reply",
         {"name": "Bob", "issue": "none"},
         None,
-        model_cfg=cfg,
         client=mock_client,
         registry=reg,
     )


### PR DESCRIPTION
## Summary
- remove ModelConfig parameter from PromptEngine.run and PromptTemplate.run
- update docs and example usage
- adjust tests for the new method signature

## Testing
- `pip install -e .[test]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aa339d7c083209b33ccaf494b687a