### PR TITLE
Add debug flag to model client factory

### DIFF
--- a/examples/basic.py
+++ b/examples/basic.py
@@ -31,7 +31,7 @@ async def main():
         api_key=os.getenv("OPENAI_API_KEY"),
         api_url=os.getenv("OPENAI_API_URL"),
     )
-    client = create_client(model_cfg)
+    client = create_client(model_cfg, is_debug=True)
     async for msg in engine.run(
         "support_reply",
         {"name": "Ada", "issue": "login failed"},

--- a/prompti/model_client/factory.py
+++ b/prompti/model_client/factory.py
@@ -12,17 +12,17 @@ from .openrouter import OpenRouterClient
 from .rust import RustModelClient
 
 
-def create_client(cfg: ModelConfig, **httpx_kw: Any):
+def create_client(cfg: ModelConfig, *, is_debug: bool = False, **httpx_kw: Any):
     """Return a ``ModelClient`` instance for ``cfg.provider``."""
     client = httpx.AsyncClient(http2=True, **httpx_kw) if httpx_kw else None
     if cfg.provider == "openai":
-        return OpenAIClient(cfg, client=client)
+        return OpenAIClient(cfg, client=client, is_debug=is_debug)
     if cfg.provider == "claude":
-        return ClaudeClient(cfg, client=client)
+        return ClaudeClient(cfg, client=client, is_debug=is_debug)
     if cfg.provider == "openrouter":
-        return OpenRouterClient(cfg, client=client)
+        return OpenRouterClient(cfg, client=client, is_debug=is_debug)
     if cfg.provider == "litellm":
-        return LiteLLMClient(cfg, client=client)
+        return LiteLLMClient(cfg, client=client, is_debug=is_debug)
     if cfg.provider == "rust":
-        return RustModelClient(cfg, client=client)
+        return RustModelClient(cfg, client=client, is_debug=is_debug)
     raise ValueError(f"Unsupported provider: {cfg.provider}")


### PR DESCRIPTION
## Summary
- make `create_client` accept an `is_debug` flag
- enable debug logging for the basic example

## Testing
- `pip install -e .[test]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aa7bf3d1c8320a3368b3cda1efb93