### PR TITLE
Introduce TemplateLoader base class

### DIFF
--- a/prompti/__init__.py
+++ b/prompti/__init__.py
@@ -9,6 +9,7 @@ from .experiment import (
     bucket,
 )
 from .loader import (
+    TemplateLoader,
     AgentaLoader,
     FileSystemLoader,
     GitHubRepoLoader,
@@ -54,6 +55,7 @@ __all__ = [
     "GrowthBookRegistry",
     "bucket",
     "Kind",
+    "TemplateLoader",
     "HTTPLoader",
     "FileSystemLoader",
     "MemoryLoader",

--- a/prompti/engine.py
+++ b/prompti/engine.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator, Awaitable, Callable
+from collections.abc import AsyncGenerator
 from pathlib import Path
 from typing import Any, Dict
 
@@ -11,13 +11,12 @@ from opentelemetry import trace
 
 from pydantic import BaseModel
 
-from .loader import FileSystemLoader, HTTPLoader, MemoryLoader
+from .loader import FileSystemLoader, HTTPLoader, MemoryLoader, TemplateLoader
 from .message import Message
 from .model_client import ModelClient, ToolParams, ToolSpec
 from .template import PromptTemplate, choose_variant
 
 _tracer = trace.get_tracer(__name__)
-TemplateLoader = Callable[[str, str | None], Awaitable[tuple[str, PromptTemplate]]]
 
 
 class PromptEngine:
@@ -99,6 +98,10 @@ class PromptEngine:
 
 class Setting(BaseModel):
     """Configuration options for :class:`PromptEngine`."""
+
+    model_config = {
+        "arbitrary_types_allowed": True,
+    }
 
     template_paths: list[Path] = [Path("./prompts")]
     cache_ttl: int = 300

--- a/prompti/loader/__init__.py
+++ b/prompti/loader/__init__.py
@@ -1,5 +1,6 @@
 """Template loaders package."""
 
+from .base import TemplateLoader
 from .agenta import AgentaLoader
 from .filesystem import FileSystemLoader
 from .github_repo import GitHubRepoLoader
@@ -11,6 +12,7 @@ from .pezzo import PezzoLoader
 from .promptlayer import PromptLayerLoader
 
 __all__ = [
+    "TemplateLoader",
     "FileSystemLoader",
     "MemoryLoader",
     "HTTPLoader",

--- a/prompti/loader/agenta.py
+++ b/prompti/loader/agenta.py
@@ -5,9 +5,10 @@ import asyncio
 import yaml
 
 from ..template import PromptTemplate, Variant
+from .base import TemplateLoader
 
 
-class AgentaLoader:
+class AgentaLoader(TemplateLoader):
     """Fetch templates from Agenta via the SDK."""
 
     def __init__(self, app_slug: str) -> None:

--- a/prompti/loader/base.py
+++ b/prompti/loader/base.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from ..template import PromptTemplate
+
+
+class TemplateLoader(ABC):
+    """Abstract base class for template loaders."""
+
+    @abstractmethod
+    async def __call__(self, name: str, label: str | None) -> tuple[str, PromptTemplate]:
+        """Return the template identified by ``name``.
+
+        Parameters
+        ----------
+        name: str
+            Template name to load.
+        label: str | None
+            Optional label used by some backends to select a version.
+        Returns
+        -------
+        tuple[str, PromptTemplate]
+            The template version and :class:`PromptTemplate` instance.
+        """
+        raise NotImplementedError

--- a/prompti/loader/filesystem.py
+++ b/prompti/loader/filesystem.py
@@ -5,9 +5,10 @@ from pathlib import Path
 import yaml
 
 from ..template import PromptTemplate, Variant
+from .base import TemplateLoader
 
 
-class FileSystemLoader:
+class FileSystemLoader(TemplateLoader):
     """Loader that reads templates from the local filesystem."""
 
     def __init__(self, base: Path) -> None:

--- a/prompti/loader/github_repo.py
+++ b/prompti/loader/github_repo.py
@@ -7,9 +7,10 @@ import httpx
 import yaml
 
 from ..template import PromptTemplate, Variant
+from .base import TemplateLoader
 
 
-class GitHubRepoLoader:
+class GitHubRepoLoader(TemplateLoader):
     """Fetch prompt files from a GitHub repository."""
 
     def __init__(self, repo: str, branch: str = "main", token: str | None = None, root: str = "prompts") -> None:

--- a/prompti/loader/http.py
+++ b/prompti/loader/http.py
@@ -4,9 +4,10 @@ import httpx
 import yaml
 
 from ..template import PromptTemplate, Variant
+from .base import TemplateLoader
 
 
-class HTTPLoader:
+class HTTPLoader(TemplateLoader):
     """Fetch templates from an HTTP endpoint."""
 
     def __init__(self, base_url: str, client: httpx.AsyncClient | None = None) -> None:

--- a/prompti/loader/langfuse.py
+++ b/prompti/loader/langfuse.py
@@ -5,9 +5,10 @@ import asyncio
 import yaml
 
 from ..template import PromptTemplate, Variant
+from .base import TemplateLoader
 
 
-class LangfuseLoader:
+class LangfuseLoader(TemplateLoader):
     """Load templates via the Langfuse SDK."""
 
     def __init__(

--- a/prompti/loader/local_git_repo.py
+++ b/prompti/loader/local_git_repo.py
@@ -5,9 +5,10 @@ from pathlib import Path
 import yaml
 
 from ..template import PromptTemplate, Variant
+from .base import TemplateLoader
 
 
-class LocalGitRepoLoader:
+class LocalGitRepoLoader(TemplateLoader):
     """Read prompt files from a local Git repository."""
 
     def __init__(self, repo_path: Path, ref: str = "HEAD") -> None:

--- a/prompti/loader/memory.py
+++ b/prompti/loader/memory.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import yaml
 
 from ..template import PromptTemplate, Variant
+from .base import TemplateLoader
 
 
-class MemoryLoader:
+class MemoryLoader(TemplateLoader):
     """Load templates from an in-memory mapping."""
 
     def __init__(self, mapping: dict[str, dict[str, str]]):

--- a/prompti/loader/pezzo.py
+++ b/prompti/loader/pezzo.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import yaml
 
 from ..template import PromptTemplate, Variant
+from .base import TemplateLoader
 
 
-class PezzoLoader:
+class PezzoLoader(TemplateLoader):
     """Retrieve prompts via the Pezzo client."""
 
     def __init__(self, project: str) -> None:

--- a/prompti/loader/promptlayer.py
+++ b/prompti/loader/promptlayer.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import httpx
 import yaml
 
-from ..template import PromptTemplate, Variant
+from ..template import PromptTemplate, Variant, ModelConfig
+from .base import TemplateLoader
 
 
-class PromptLayerLoader:
+class PromptLayerLoader(TemplateLoader):
     """Load templates from PromptLayer."""
 
     URL = "https://api.promptlayer.com/prompt-templates"


### PR DESCRIPTION
## Summary
- add new `TemplateLoader` abstract class
- update all loaders to subclass `TemplateLoader`
- expose the base class via `prompti` package
- use the new class in `PromptEngine` and configuration

## Testing
- `uv pip install --system -e .[test]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bd955a1b883208586b5b14fe2b212