### PR TITLE
Remove run method from PromptTemplate

### DIFF
--- a/examples/basic.py
+++ b/examples/basic.py
@@ -35,7 +35,6 @@ async def main():
     async for msg in engine.run(
         "support_reply",
         {"name": "Ada", "issue": "login failed"},
-        tags=None,
         client=client,
         stream=True,
     ):

--- a/prompti/engine.py
+++ b/prompti/engine.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel
 
 from .loader import FileSystemLoader, HTTPLoader, MemoryLoader
 from .message import Message
-from .model_client import ModelClient, ToolParams, ToolSpec
+from .model_client import ModelClient, RunParams, ToolParams, ToolSpec
 from .template import PromptTemplate, choose_variant
 
 _tracer = trace.get_tracer(__name__)
@@ -62,9 +62,13 @@ class PromptEngine:
     ) -> AsyncGenerator[Message, None]:
         """Stream messages produced by running the template via ``client``."""
         tmpl = await self._resolve(template_name, None)
+        ctx = ctx or variables
 
         if variant is None:
-            variant = choose_variant(tmpl, ctx or variables) or next(iter(tmpl.variants))
+            variant = choose_variant(tmpl, ctx) or next(iter(tmpl.variants))
+
+        messages, var = tmpl.format(variables, variant=variant, ctx=ctx)
+        params = RunParams(messages=messages, tool_params=tool_params, **run_params)
 
         with _tracer.start_as_current_span(
             "prompt.run",
@@ -74,14 +78,8 @@ class PromptEngine:
                 "variant": variant,
             },
         ):
-            async for msg in tmpl.run(
-                variables,
-                client=client,
-                variant=variant,
-                ctx=ctx or variables,
-                tool_params=tool_params,
-                **run_params,
-            ):
+            client.cfg = var.model_cfg
+            async for msg in client.run(params):
                 yield msg
 
     @classmethod

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,38 @@
+import pytest
+
+from prompti.engine import PromptEngine
+from prompti.loader import MemoryLoader
+from prompti.model_client import ModelClient, ModelConfig, RunParams
+from prompti.message import Message
+
+
+class DummyClient(ModelClient):
+    provider = "dummy"
+
+    async def _run(self, params: RunParams):
+        yield Message(role="assistant", kind="text", content="ok")
+
+
+@pytest.mark.asyncio
+async def test_engine_run_uses_model_cfg():
+    yaml_text = """
+name: x
+version: '1'
+variants:
+  base:
+    contains: []
+    model_config:
+      provider: dummy
+      model: x
+    messages:
+      - role: user
+        parts: []
+"""
+    engine = PromptEngine([MemoryLoader({"x": {"yaml": yaml_text}})])
+    client = DummyClient(ModelConfig(provider="dummy", model="y"))
+
+    out = [
+        m async for m in engine.run("x", {}, client=client, variant="base", stream=False)
+    ]
+    assert out[0].content == "ok"
+    assert client.cfg == ModelConfig(provider="dummy", model="x")

--- a/tests/test_template_format.py
+++ b/tests/test_template_format.py
@@ -3,8 +3,7 @@ from pathlib import Path
 
 from prompti.loader import FileSystemLoader
 from prompti.template import PromptTemplate, Variant
-from prompti.model_client import ModelClient, ModelConfig, RunParams
-from prompti.message import Message
+from prompti.model_client import ModelConfig
 
 
 @pytest.mark.asyncio
@@ -95,35 +94,4 @@ def test_complex_jinja_multi_message():
     msgs, _ = template.format({"tasks": tasks}, variant="base")
     content = msgs[0].content
     assert "Fix" in content and "Doc" in content
-
-
-@pytest.mark.asyncio
-async def test_template_run_uses_model_cfg():
-    class DummyClient(ModelClient):
-        provider = "dummy"
-
-        async def _run(self, params: RunParams):
-            yield Message(role="assistant", kind="text", content="ok")
-
-    tmpl_cfg = ModelConfig(provider="dummy", model="x")
-    client = DummyClient(ModelConfig(provider="dummy", model="y"))
-    template = PromptTemplate(
-        name="x",
-        description="",
-        version="1",
-        variants={
-            "base": Variant(
-                contains=[],
-                model_config=tmpl_cfg,
-                messages=[{"role": "user", "parts": []}],
-            )
-        },
-    )
-
-    out = [
-        m
-        async for m in template.run({}, client=client, variant="base", stream=False)
-    ]
-    assert out[0].content == "ok"
-    assert client.cfg == tmpl_cfg
 


### PR DESCRIPTION
## Summary
- drop unused run method from `PromptTemplate`
- update `PromptEngine.run` to call `ModelClient` directly
- move engine run test to its own module and clean up format tests
- fix example code to match new engine API

## Testing
- `pip install -e .[test]`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685bd901def883209c0b0fec4081b6ea