### PR TITLE
Add load method to PromptEngine

### DIFF
--- a/prompti/engine.py
+++ b/prompti/engine.py
@@ -35,6 +35,10 @@ class PromptEngine:
                 return tmpl
         raise FileNotFoundError(name)
 
+    async def load(self, template_name: str) -> PromptTemplate:
+        """Resolve and cache ``template_name``."""
+        return await self._resolve(template_name, None)
+
     async def format(
         self,
         template_name: str,

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,51 @@
+import pytest
+from pathlib import Path
+
+from prompti.engine import PromptEngine
+from prompti.loader import FileSystemLoader, TemplateLoader
+from prompti.template import PromptTemplate, Variant
+from prompti.model_client import ModelConfig
+
+
+@pytest.mark.asyncio
+async def test_load_returns_template():
+    engine = PromptEngine([FileSystemLoader(Path("./prompts"))])
+    tmpl = await engine.load("summary")
+    assert tmpl.name == "summary"
+    assert tmpl.version == "1.0"
+
+
+@pytest.mark.asyncio
+async def test_load_caches_result():
+    class CountingLoader(TemplateLoader):
+        def __init__(self):
+            self.calls = 0
+
+        async def __call__(self, name: str, label: str | None):
+            self.calls += 1
+            return "1", PromptTemplate(
+                name=name,
+                description="",
+                version="1",
+                variants={
+                    "base": Variant(
+                        contains=[],
+                        model_config=ModelConfig(provider="dummy", model="x"),
+                        messages=[],
+                    )
+                },
+            )
+
+    loader = CountingLoader()
+    engine = PromptEngine([loader])
+    tmpl1 = await engine.load("demo")
+    tmpl2 = await engine.load("demo")
+    assert tmpl1 is tmpl2
+    assert loader.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_load_missing_raises():
+    engine = PromptEngine([FileSystemLoader(Path("./prompts"))])
+    with pytest.raises(FileNotFoundError):
+        await engine.load("nonexistent")


### PR DESCRIPTION
## Summary
- add `load` method to `PromptEngine`
- test engine loading, caching, and error handling

## Testing
- `uv pip install --system -e .[test]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bdbdfb6908320a548ad124939922d