### PR TITLE
Move choose_variant into PromptTemplate

### DIFF
--- a/prompti/__init__.py
+++ b/prompti/__init__.py
@@ -32,12 +32,11 @@ from .model_client import (
     create_client,
 )
 from .replay import ModelClientRecorder, ReplayEngine
-from .template import PromptTemplate, choose_variant
+from .template import PromptTemplate
 
 __all__ = [
     "Message",
     "PromptTemplate",
-    "choose_variant",
     "PromptEngine",
     "ModelClient",
     "ModelConfig",

--- a/prompti/engine.py
+++ b/prompti/engine.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel
 from .loader import FileSystemLoader, HTTPLoader, MemoryLoader, TemplateLoader
 from .message import Message
 from .model_client import ModelClient, RunParams, ToolParams, ToolSpec
-from .template import PromptTemplate, choose_variant
+from .template import PromptTemplate
 
 _tracer = trace.get_tracer(__name__)
 
@@ -68,7 +68,7 @@ class PromptEngine:
         ctx = ctx or variables
 
         if variant is None:
-            variant = choose_variant(tmpl, ctx) or next(iter(tmpl.variants))
+            variant = tmpl.choose_variant(ctx) or next(iter(tmpl.variants))
 
         messages, var = tmpl.format(variables, variant=variant, ctx=ctx)
         params = RunParams(messages=messages, tool_params=tool_params, **run_params)

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -6,7 +6,7 @@ import httpx
 import pytest
 
 from prompti.experiment import GrowthBookRegistry, UnleashRegistry, bucket
-from prompti.template import choose_variant, Variant, PromptTemplate
+from prompti.template import Variant, PromptTemplate
 from prompti.message import Message
 from prompti.model_client import ModelClient, ModelConfig
 
@@ -54,4 +54,4 @@ def test_choose_variant():
         },
     )
     ctx = {"role": "vip-user"}
-    assert choose_variant(tmpl, ctx) == "a"
+    assert tmpl.choose_variant(ctx) == "a"


### PR DESCRIPTION
## Summary
- convert `choose_variant` from a free function to a `PromptTemplate` method
- update engine and exports to use the new method
- adjust tests accordingly

## Testing
- `pip install -e .[test]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685be0566ee4832093ea1ef8367fcc67