### PR TITLE
Update examples for latest API

### DIFF
--- a/examples/basic.py
+++ b/examples/basic.py
@@ -1,44 +1,31 @@
-"""Example demonstrating PromptI with the LiteLLM client."""
+"""Minimal example demonstrating PromptI with LiteLLM."""
 
 import asyncio
-import logging
 import os
-
-from dotenv import load_dotenv
 
 from prompti.engine import PromptEngine, Setting
 from prompti.model_client import ModelConfig, create_client
 
 
-async def main():
-    """Run a simple support-reply prompt via LiteLLM and print the results."""
+async def main() -> None:
+    """Render ``support_reply`` and print the response."""
 
-    # Configure logging to write to console
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-
-    # Configure ModelClient logger to INFO level
-    client_logger = logging.getLogger("model_client")
-    client_logger.setLevel(logging.INFO)
-
-    # Load environment variables
-    load_dotenv()
-
-    settings = Setting(template_paths=["./prompts"])
-    engine = PromptEngine.from_setting(settings)
-    model_cfg = ModelConfig(
+    engine = PromptEngine.from_setting(Setting())
+    cfg = ModelConfig(
         provider="litellm",
         model=os.getenv("MODEL_NAME", "gpt-3.5-turbo"),
         api_key=os.getenv("LITELLM_API_KEY"),
         api_url=os.getenv("LITELLM_ENDPOINT"),
     )
-    client = create_client(model_cfg, is_debug=True)
+    client = create_client(cfg)
+
     async for msg in engine.run(
         "support_reply",
         {"name": "Ada", "issue": "login failed"},
         client=client,
         stream=True,
     ):
-        print(f"{msg.role}/{msg.kind}: {msg.content}")
+        print(msg.content)
 
 
 if __name__ == "__main__":

--- a/examples/chat_cli.py
+++ b/examples/chat_cli.py
@@ -107,7 +107,7 @@ async def main() -> None:
         provider=args.provider,
         model=args.model,
         api_key=args.api_key,
-        api_base=args.api_url,
+        api_url=args.api_url,
     )
     client = create_client(cfg)
 


### PR DESCRIPTION
## Summary
- simplify `examples/basic.py`
- preload template in `basic.py` removed for simplicity
- update CLI example to use `api_url` field

## Testing
- `pip install -e .[test]`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685be073fb1083209f19fbc77004d62f