### PR TITLE
Rename Variant contains to selector

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -38,7 +38,7 @@ class ModelConfig(BaseModel):
 
 
 class Variant(BaseModel):
-    contains: list[str]
+    selector: list[str]
     model_config: ModelConfig
     messages: list[dict]
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ template = PromptTemplate(
     version="1.0",
     variants={
         "default": Variant(
-            contains=[],
+            selector=[],
             model_config=ModelConfig(provider="litellm", model="gpt-4o"),
             messages=[{"role": "user", "parts": [{"type": "text", "text": "Hello {{ name }}!"}]}],
         )
@@ -147,7 +147,7 @@ multi = PromptTemplate(
     version="1.0",
     variants={
         "default": Variant(
-            contains=[],
+            selector=[],
             model_config=ModelConfig(provider="litellm", model="gpt-3.5-turbo"),
             messages=[
                 {"role": "system", "parts": [{"type": "text", "text": "Analyze file"}]},
@@ -176,7 +176,7 @@ tmpl = PromptTemplate(
     version="1.0",
     variants={
         "default": Variant(
-            contains=[],
+            selector=[],
             model_config=ModelConfig(provider="litellm", model="gpt-3.5-turbo"),
             messages=[
                 {

--- a/prompti/template.py
+++ b/prompti/template.py
@@ -38,7 +38,7 @@ def _ctx_to_flat(ctx: Dict[str, Any]) -> str:
 class Variant(BaseModel):
     """Single experiment arm."""
 
-    contains: list[str] = []
+    selector: list[str] = []
     model_cfg: ModelConfig = Field(..., alias="model_config")
     messages: list[dict]
     tools: list[dict] | None = None
@@ -59,7 +59,7 @@ class PromptTemplate(BaseModel):
         """Return the first variant id whose tokens all appear in ``ctx``."""
         haystack = _ctx_to_flat(ctx)
         for vid, var in self.variants.items():
-            if all(tok.lower() in haystack for tok in var.contains):
+            if all(tok.lower() in haystack for tok in var.selector):
                 return vid
         return None
 

--- a/prompts/multi_modal_analysis.yaml
+++ b/prompts/multi_modal_analysis.yaml
@@ -4,7 +4,7 @@ version: "1.0"
 tags: [analysis]
 variants:
   default:
-    contains: []
+    selector: []
     model_config:
       provider: litellm
       model: gpt-4o

--- a/prompts/summary.yaml
+++ b/prompts/summary.yaml
@@ -4,7 +4,7 @@ version: "1.0"
 tags: [summarization, text-processing]
 variants:
   default:
-    contains: []
+    selector: []
     model_config:
       provider: litellm
       model: gpt-3.5-turbo

--- a/prompts/support_reply.yaml
+++ b/prompts/support_reply.yaml
@@ -4,7 +4,7 @@ version: "1.0"
 tags: [customer-support, automated-response]
 variants:
   default:
-    contains: []
+    selector: []
     model_config:
       provider: litellm
       model: gpt-3.5-turbo

--- a/prompts/task_manager.yaml
+++ b/prompts/task_manager.yaml
@@ -4,7 +4,7 @@ version: "1.0"
 tags: [todo]
 variants:
   default:
-    contains: []
+    selector: []
     model_config:
       provider: litellm
       model: gpt-3.5-turbo

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -22,7 +22,7 @@ name: x
 version: '1'
 variants:
   base:
-    contains: []
+    selector: []
     model_config:
       provider: dummy
       model: x
@@ -64,7 +64,7 @@ async def test_load_caches_result():
                 version="1",
                 variants={
                     "base": Variant(
-                        contains=[],
+                        selector=[],
                         model_config=ModelConfig(provider="dummy", model="x"),
                         messages=[],
                     )

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -49,8 +49,8 @@ def test_choose_variant():
         description="",
         version="1",
         variants={
-            "a": Variant(contains=["vip"], model_config=ModelConfig(provider="x", model="m1"), messages=[]),
-            "b": Variant(contains=["guest"], model_config=ModelConfig(provider="x", model="m1"), messages=[]),
+            "a": Variant(selector=["vip"], model_config=ModelConfig(provider="x", model="m1"), messages=[]),
+            "b": Variant(selector=["guest"], model_config=ModelConfig(provider="x", model="m1"), messages=[]),
         },
     )
     ctx = {"role": "vip-user"}

--- a/tests/test_template_format.py
+++ b/tests/test_template_format.py
@@ -24,7 +24,7 @@ def test_single_message_format():
         version="1.0",
         variants={
             "base": Variant(
-                contains=[],
+                selector=[],
                 model_config=ModelConfig(provider="dummy", model="x"),
                 messages=[
                     {
@@ -48,7 +48,7 @@ def test_multi_message_different_kinds(tmp_path: Path):
         version="1.0",
         variants={
             "base": Variant(
-                contains=[],
+                selector=[],
                 model_config=ModelConfig(provider="dummy", model="x"),
                 messages=[
                     {"role": "system", "parts": [{"type": "text", "text": "Analyze file"}]},
@@ -69,7 +69,7 @@ def test_complex_jinja_multi_message():
         version="1.0",
         variants={
             "base": Variant(
-                contains=[],
+                selector=[],
                 model_config=ModelConfig(provider="dummy", model="x"),
                 messages=[
                     {


### PR DESCRIPTION
## Summary
- rename `Variant.contains` to `selector`
- adjust template logic for the new field
- update docs, YAML examples and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685be1acc8d48320a5cdb0536cf31140