### PR TITLE
Refactor loaders API

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -71,7 +71,7 @@ class PromptEngine:
     async def run(self, name: str, variables: dict, client: ModelClient, *, variant: str | None = None, tool_params: ToolParams | list[ToolSpec] | list[dict] | None = None) -> AsyncGenerator[Message, None]: ...
 ```
 
-* 多种 `TemplateLoader`（FS / HTTP / Memory）+ `async-lru` TTL 缓存。
+* 多种 `load` 实现（FS / HTTP / Memory）+ `async-lru` TTL 缓存。
 
 #### 3.3 ModelClient
 
@@ -284,11 +284,11 @@ from jinja2 import Environment, StrictUndefined
 env = Environment(undefined=StrictUndefined)
 
 @alru_cache(maxsize=128, ttl=60)
-async def fetch_template(name: str, label: str):
+async def fetch_template(name: str, tags: str):
     ...  # 解析版本约束，拉取 YAML 文本
 
-async def render(name: str, label: str, **vars):
-    raw_yaml = await fetch_template(name, label)
+async def render(name: str, tags: str, **vars):
+    raw_yaml = await fetch_template(name, tags)
     data = yaml.safe_load(raw_yaml)
     for msg in data["messages"]:
         for part in msg.get("parts", []):

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ repositories, or a local Git repo. Each loader exposes the same async call
 contract:
 
 ```python
-version, tmpl = await loader("my_prompt", label="prod")
+version, tmpl = await loader.load("my_prompt", tags="prod")
 ```
 
 To wire them up:

--- a/prompti/engine.py
+++ b/prompti/engine.py
@@ -28,9 +28,9 @@ class PromptEngine:
         self._cache_ttl = cache_ttl
         self._resolve = alru_cache(maxsize=128, ttl=cache_ttl)(self._resolve_impl)
 
-    async def _resolve_impl(self, name: str, label: str | None) -> PromptTemplate:
+    async def _resolve_impl(self, name: str, tags: str | None) -> PromptTemplate:
         for loader in self._loaders:
-            version, tmpl = await loader(name, label)
+            version, tmpl = await loader.load(name, tags)
             if tmpl:
                 return tmpl
         raise FileNotFoundError(name)

--- a/prompti/loader/agenta.py
+++ b/prompti/loader/agenta.py
@@ -17,12 +17,12 @@ class AgentaLoader(TemplateLoader):
         ag.init()
         self.app_slug = app_slug
 
-    async def __call__(self, name: str, label: str | None) -> tuple[str, PromptTemplate]:
+    async def load(self, name: str, tags: str | None) -> tuple[str, PromptTemplate]:
         cfg = await asyncio.to_thread(
             ag.ConfigManager.get_from_registry,
             app_slug=self.app_slug,
             variant_slug=name,
-            environment_slug=label or "production",
+            environment_slug=tags or "production",
         )
         yaml_blob = yaml.safe_dump(cfg["prompt"])
         meta = yaml.safe_load(yaml_blob)
@@ -31,7 +31,7 @@ class AgentaLoader(TemplateLoader):
             name=meta.get("name", name),
             description=meta.get("description", ""),
             version=str(cfg.get("variant_version", "0")),
-            tags=meta.get("tags", [label] if label else ["production"]),
+            tags=meta.get("tags", [tags] if tags else ["production"]),
             variants={k: Variant(**v) for k, v in meta.get("variants", {}).items()},
             yaml=yaml_blob,
         )

--- a/prompti/loader/base.py
+++ b/prompti/loader/base.py
@@ -9,15 +9,15 @@ class TemplateLoader(ABC):
     """Abstract base class for template loaders."""
 
     @abstractmethod
-    async def __call__(self, name: str, label: str | None) -> tuple[str, PromptTemplate]:
+    async def load(self, name: str, tags: str | None) -> tuple[str, PromptTemplate]:
         """Return the template identified by ``name``.
 
         Parameters
         ----------
         name: str
             Template name to load.
-        label: str | None
-            Optional label used by some backends to select a version.
+        tags: str | None
+            Optional tags used by some backends to select a version.
         Returns
         -------
         tuple[str, PromptTemplate]

--- a/prompti/loader/filesystem.py
+++ b/prompti/loader/filesystem.py
@@ -15,7 +15,7 @@ class FileSystemLoader(TemplateLoader):
         """Create loader with a base directory."""
         self.base = base
 
-    async def __call__(self, name: str, label: str | None) -> tuple[str, PromptTemplate]:
+    async def load(self, name: str, tags: str | None) -> tuple[str, PromptTemplate]:
         """Load and return the template identified by ``name``."""
         path = self.base / f"{name}.yaml"
         text = path.read_text()

--- a/prompti/loader/github_repo.py
+++ b/prompti/loader/github_repo.py
@@ -20,7 +20,7 @@ class GitHubRepoLoader(TemplateLoader):
         self.headers = {"Authorization": f"token {token}"} if token else {}
         self.client = httpx.AsyncClient()
 
-    async def __call__(self, name: str, label: str | None) -> tuple[str, PromptTemplate]:
+    async def load(self, name: str, tags: str | None) -> tuple[str, PromptTemplate]:
         path = f"{self.root}/{name}.yaml"
         url = f"https://api.github.com/repos/{self.repo}/contents/{path}"
         resp = await self.client.get(url, params={"ref": self.branch}, headers=self.headers)

--- a/prompti/loader/http.py
+++ b/prompti/loader/http.py
@@ -15,9 +15,9 @@ class HTTPLoader(TemplateLoader):
         self.base_url = base_url.rstrip("/")
         self.client = client or httpx.AsyncClient()
 
-    async def __call__(self, name: str, label: str | None) -> tuple[str, PromptTemplate]:
+    async def load(self, name: str, tags: str | None) -> tuple[str, PromptTemplate]:
         """Retrieve ``name`` from the remote registry."""
-        params = {"label": label} if label else {}
+        params = {"label": tags} if tags else {}
         resp = await self.client.get(f"{self.base_url}/templates/{name}", params=params)
         if resp.status_code != 200:
             raise FileNotFoundError(name)

--- a/prompti/loader/langfuse.py
+++ b/prompti/loader/langfuse.py
@@ -21,8 +21,8 @@ class LangfuseLoader(TemplateLoader):
 
         self.client = get_client(public_key=public_key, secret_key=secret_key, base_url=base_url)
 
-    async def __call__(self, name: str, label: str | None) -> tuple[str, PromptTemplate]:
-        prm = await asyncio.to_thread(self.client.prompts().get_prompt, name, label=label)
+    async def load(self, name: str, tags: str | None) -> tuple[str, PromptTemplate]:
+        prm = await asyncio.to_thread(self.client.prompts().get_prompt, name, label=tags)
         yaml_blob = prm.yaml
         meta = yaml.safe_load(yaml_blob)
         tmpl = PromptTemplate(

--- a/prompti/loader/local_git_repo.py
+++ b/prompti/loader/local_git_repo.py
@@ -17,7 +17,7 @@ class LocalGitRepoLoader(TemplateLoader):
         self.repo = pygit2.Repository(str(repo_path))
         self.ref = ref
 
-    async def __call__(self, name: str, label: str | None) -> tuple[str, PromptTemplate]:
+    async def load(self, name: str, tags: str | None) -> tuple[str, PromptTemplate]:
         commit = self.repo.revparse_single(self.ref)
         tree = commit.tree
         blob = tree[f"prompts/{name}.yaml"]

--- a/prompti/loader/memory.py
+++ b/prompti/loader/memory.py
@@ -13,7 +13,7 @@ class MemoryLoader(TemplateLoader):
         """Store the mapping of template name to template data."""
         self.mapping = mapping
 
-    async def __call__(self, name: str, label: str | None) -> tuple[str, PromptTemplate]:
+    async def load(self, name: str, tags: str | None) -> tuple[str, PromptTemplate]:
         """Return the template ``name`` from the mapping."""
         data = self.mapping.get(name)
         if not data:

--- a/prompti/loader/pezzo.py
+++ b/prompti/loader/pezzo.py
@@ -14,8 +14,8 @@ class PezzoLoader(TemplateLoader):
 
         self.client = PezzoClient(project=project)
 
-    async def __call__(self, name: str, label: str | None) -> tuple[str, PromptTemplate]:
-        prompt = await self.client.get_prompt(slug=name, environment="production", version_tag=label)
+    async def load(self, name: str, tags: str | None) -> tuple[str, PromptTemplate]:
+        prompt = await self.client.get_prompt(slug=name, environment="production", version_tag=tags)
         yaml_blob = prompt["yaml"]
         meta = yaml.safe_load(yaml_blob)
         tmpl = PromptTemplate(

--- a/prompti/loader/promptlayer.py
+++ b/prompti/loader/promptlayer.py
@@ -16,8 +16,8 @@ class PromptLayerLoader(TemplateLoader):
         self.api_key = api_key
         self.client = client or httpx.AsyncClient()
 
-    async def __call__(self, name: str, label: str | None) -> tuple[str, PromptTemplate]:
-        body = {"label": label} if label else {}
+    async def load(self, name: str, tags: str | None) -> tuple[str, PromptTemplate]:
+        body = {"label": tags} if tags else {}
         resp = await self.client.post(
             f"{self.URL}/{name}",
             headers={"X-API-KEY": self.api_key, "Content-Type": "application/json"},
@@ -33,7 +33,7 @@ class PromptLayerLoader(TemplateLoader):
             name=name,
             description="",
             version=str(data["version"]),
-            tags=[label] if label else [],
+            tags=[tags] if tags else [],
             variants={"default": Variant(model_config=ModelConfig(provider="litellm", model="unknown"), messages=content)},
             yaml=yaml_blob,
         )

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -56,7 +56,7 @@ async def test_load_caches_result():
         def __init__(self):
             self.calls = 0
 
-        async def __call__(self, name: str, label: str | None):
+        async def load(self, name: str, tags: str | None):
             self.calls += 1
             return "1", PromptTemplate(
                 name=name,

--- a/tests/test_template_format.py
+++ b/tests/test_template_format.py
@@ -9,7 +9,7 @@ from prompti.model_client import ModelConfig
 @pytest.mark.asyncio
 async def test_load_from_file_has_expected_fields():
     loader = FileSystemLoader(Path("./prompts"))
-    version, tmpl = await loader("summary", None)
+    version, tmpl = await loader.load("summary", None)
     assert version == "1.0"
     assert tmpl.name == "summary"
     assert tmpl.version == "1.0"


### PR DESCRIPTION
## Summary
- rename template loader call method to `load`
- replace `label` parameter with `tags`
- update engine and tests for new loader API
- document new `load()` interface

## Testing
- `pip install -e .[test]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685be439df1c8320bd1058118d67235e