### PR TITLE
Add OpenAI message conversion helpers

### DIFF
--- a/tests/test_template_format.py
+++ b/tests/test_template_format.py
@@ -95,3 +95,52 @@ def test_complex_jinja_multi_message():
     content = msgs[0].content
     assert "Fix" in content and "Doc" in content
 
+
+def test_to_openai_messages_simple():
+    template = PromptTemplate(
+        name="hello",
+        description="",
+        version="1.0",
+        variants={
+            "base": Variant(
+                selector=[],
+                model_config=ModelConfig(provider="dummy", model="x"),
+                messages=[
+                    {
+                        "role": "user",
+                        "parts": [{"type": "text", "text": "Hello {{ name }}!"}],
+                    }
+                ],
+            )
+        },
+    )
+    msgs, _ = template.to_openai_messages({"name": "World"}, variant="base")
+    assert msgs == [{"role": "user", "content": "Hello World!"}]
+
+
+def test_to_openai_messages_with_file(tmp_path: Path):
+    file_path = tmp_path / "f.txt"
+    template = PromptTemplate(
+        name="file",
+        description="",
+        version="1.0",
+        variants={
+            "base": Variant(
+                selector=[],
+                model_config=ModelConfig(provider="dummy", model="x"),
+                messages=[
+                    {
+                        "role": "user",
+                        "parts": [
+                            {"type": "text", "text": "See"},
+                            {"type": "file", "file": str(file_path)},
+                        ],
+                    }
+                ],
+            )
+        },
+    )
+    msgs, _ = template.to_openai_messages({}, variant="base")
+    expected = [{"role": "user", "content": f"See\n[FILE]({file_path})"}]
+    assert msgs == expected
+


### PR DESCRIPTION
## Summary
- extend `PromptTemplate` with `_part_to_str` helper and `to_openai_messages`
- test converting templates directly to OpenAI-style messages

## Testing
- `pip install -e .[test]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685be50923fc8320bf7b3dd301b16d9c