### PR TITLE
Support format option in PromptTemplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,9 @@ template = PromptTemplate(
     },
 )
 
-msgs, _ = template.format({"name": "World"})
+# ``format`` defaults to ``"openai"``. Use ``format="a2a"`` for raw A2A messages
+# or ``format="claude"``/``format="litellm"`` for provider‑specific structures.
+msgs, _ = template.format({"name": "World"}, format="a2a")
 print(msgs[0].content)
 ```
 
@@ -157,7 +159,7 @@ multi = PromptTemplate(
     },
 )
 
-msgs, _ = multi.format({"file_path": "/tmp/document.pdf"})
+msgs, _ = multi.format({"file_path": "/tmp/document.pdf"}, format="a2a")
 for m in msgs:
     print(m.role, m.kind, m.content)
 ```
@@ -193,7 +195,7 @@ tmpl = PromptTemplate(
     },
 )
 
-msgs, _ = tmpl.format({"tasks": tasks})
+msgs, _ = tmpl.format({"tasks": tasks}, format="a2a")
 print(msgs[0].content)
 ```
 

--- a/prompti/engine.py
+++ b/prompti/engine.py
@@ -49,7 +49,7 @@ class PromptEngine:
     ) -> list[Message]:
         """Return formatted messages for ``template_name``."""
         tmpl = await self._resolve(template_name, None)
-        msgs, _ = tmpl.format(variables, variant=variant, ctx=ctx)
+        msgs, _ = tmpl.format(variables, variant=variant, ctx=ctx, format="a2a")
         return msgs
 
     async def run(
@@ -70,7 +70,9 @@ class PromptEngine:
         if variant is None:
             variant = tmpl.choose_variant(ctx) or next(iter(tmpl.variants))
 
-        messages, var = tmpl.format(variables, variant=variant, ctx=ctx)
+        messages, var = tmpl.format(
+            variables, variant=variant, ctx=ctx, format="a2a"
+        )
         params = RunParams(messages=messages, tool_params=tool_params, **run_params)
 
         with _tracer.start_as_current_span(


### PR DESCRIPTION
## Summary
- add support for `openai`, `claude`, `litellm` and `a2a` formats to `PromptTemplate.format`
- use the default `openai` format unless specified otherwise
- document format options in README examples
- test new `claude` output mode

## Testing
- `uv pip install --system -e .`
- `pip install -e .[test]`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685be756afd483209b1790aacc972217