### PR TITLE
Add missing module docstrings

### DIFF
--- a/prompti/engine.py
+++ b/prompti/engine.py
@@ -1,5 +1,7 @@
 """Core engine that resolves templates and executes them with model clients."""
 
+from __future__ import annotations
+
 from collections.abc import AsyncGenerator
 from pathlib import Path
 from typing import Any

--- a/prompti/loader/__init__.py
+++ b/prompti/loader/__init__.py
@@ -2,7 +2,7 @@
 
 from .agenta import AgentaLoader
 from .base import TemplateLoader
-from .filesystem import FileSystemLoader
+from .file import FileSystemLoader
 from .github_repo import GitHubRepoLoader
 from .http import HTTPLoader
 from .langfuse import LangfuseLoader

--- a/prompti/loader/agenta.py
+++ b/prompti/loader/agenta.py
@@ -1,3 +1,5 @@
+"""Loader that fetches prompt templates from the Agenta registry."""
+
 import asyncio
 
 import yaml

--- a/prompti/loader/base.py
+++ b/prompti/loader/base.py
@@ -1,3 +1,5 @@
+"""Abstract template loader interface and version utilities."""
+
 from abc import ABC, abstractmethod
 
 import semantic_version

--- a/prompti/loader/file.py
+++ b/prompti/loader/file.py
@@ -1,3 +1,5 @@
+"""Filesystem-based loader for prompt templates."""
+
 from pathlib import Path
 
 import yaml

--- a/prompti/loader/github_repo.py
+++ b/prompti/loader/github_repo.py
@@ -1,3 +1,5 @@
+"""Load prompt templates directly from a GitHub repository."""
+
 import base64
 import codecs
 

--- a/prompti/loader/http.py
+++ b/prompti/loader/http.py
@@ -1,3 +1,5 @@
+"""Fetch prompt templates from a remote HTTP service."""
+
 import httpx
 import yaml
 

--- a/prompti/loader/langfuse.py
+++ b/prompti/loader/langfuse.py
@@ -1,3 +1,5 @@
+"""Load prompt templates using the Langfuse SDK."""
+
 import asyncio
 
 import yaml

--- a/prompti/loader/local_git_repo.py
+++ b/prompti/loader/local_git_repo.py
@@ -1,3 +1,5 @@
+"""Load templates stored in a local Git repository."""
+
 from pathlib import Path
 
 import yaml

--- a/prompti/loader/memory.py
+++ b/prompti/loader/memory.py
@@ -1,3 +1,5 @@
+"""Simple loader that serves templates from an in-memory mapping."""
+
 import yaml
 
 from ..template import PromptTemplate, Variant

--- a/prompti/loader/pezzo.py
+++ b/prompti/loader/pezzo.py
@@ -1,3 +1,5 @@
+"""Load prompt templates using the Pezzo cloud service."""
+
 import yaml
 
 from ..template import PromptTemplate, Variant

--- a/prompti/loader/promptlayer.py
+++ b/prompti/loader/promptlayer.py
@@ -1,3 +1,5 @@
+"""Load templates from the PromptLayer service."""
+
 from __future__ import annotations
 
 import httpx

--- a/prompti/model_client/factory.py
+++ b/prompti/model_client/factory.py
@@ -1,3 +1,5 @@
+"""Factory for constructing model client implementations."""
+
 from __future__ import annotations
 
 from typing import Any

--- a/prompti/template.py
+++ b/prompti/template.py
@@ -1,8 +1,11 @@
 """Prompt template with variant selection and Jinja rendering."""
 
+from __future__ import annotations
+
 import json
 import re
 from time import perf_counter
+from typing import Any
 
 import yaml
 from jinja2 import StrictUndefined


### PR DESCRIPTION
## Summary
- ensure every module under `prompti` has a module level docstring
- import `from __future__ import annotations` where needed
- update loader package init to import `FileSystemLoader` correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c9d8724548320bdb92d414d60d021