### PR TITLE
Add missing docstrings and fix lint

### DIFF
--- a/prompti/loader/agenta.py
+++ b/prompti/loader/agenta.py
@@ -12,6 +12,7 @@ class AgentaLoader(TemplateLoader):
     """Fetch templates from Agenta via the SDK."""
 
     def __init__(self, app_slug: str) -> None:
+        """Create a loader for the given Agenta application slug."""
         import agenta as ag
 
         ag.init()

--- a/prompti/loader/base.py
+++ b/prompti/loader/base.py
@@ -31,6 +31,7 @@ class TemplateLoader(ABC):
         -------
         List[VersionEntry]
             List of available versions with their IDs and tags.
+
         """
         raise NotImplementedError
 
@@ -49,6 +50,7 @@ class TemplateLoader(ABC):
         -------
         PromptTemplate
             The template instance.
+
         """
         raise NotImplementedError
 
@@ -74,6 +76,7 @@ class TemplateLoader(ABC):
         -------
         PromptTemplate
             The resolved template instance.
+
         """
         # Get all available versions
         versions = await self.list_versions(name)
@@ -102,6 +105,7 @@ class TemplateLoader(ABC):
         -------
         VersionEntry | None
             The best matching version, or None if no match found.
+
         """
         if not versions:
             return None
@@ -143,6 +147,7 @@ class TemplateLoader(ABC):
         -------
         tuple[str, List[str]]
             Version specification and list of required tags.
+
         """
         if not selector:
             raise ValueError("Version selector cannot be empty")

--- a/prompti/loader/github_repo.py
+++ b/prompti/loader/github_repo.py
@@ -14,6 +14,7 @@ class GitHubRepoLoader(TemplateLoader):
     """Fetch prompt files from a GitHub repository."""
 
     def __init__(self, repo: str, branch: str = "main", token: str | None = None, root: str = "prompts") -> None:
+        """Initialize the loader with repository details."""
         self.repo = repo
         self.branch = branch
         self.root = root

--- a/prompti/loader/langfuse.py
+++ b/prompti/loader/langfuse.py
@@ -17,6 +17,7 @@ class LangfuseLoader(TemplateLoader):
         secret_key: str,
         base_url: str = "https://cloud.langfuse.com",
     ) -> None:
+        """Initialize the loader with API credentials."""
         from langfuse import get_client
 
         self.client = get_client(public_key=public_key, secret_key=secret_key, base_url=base_url)

--- a/prompti/loader/local_git_repo.py
+++ b/prompti/loader/local_git_repo.py
@@ -12,6 +12,7 @@ class LocalGitRepoLoader(TemplateLoader):
     """Read prompt files from a local Git repository."""
 
     def __init__(self, repo_path: Path, ref: str = "HEAD") -> None:
+        """Create the loader pointing at ``repo_path`` and ``ref``."""
         import pygit2
 
         self.repo = pygit2.Repository(str(repo_path))

--- a/prompti/loader/pezzo.py
+++ b/prompti/loader/pezzo.py
@@ -10,6 +10,7 @@ class PezzoLoader(TemplateLoader):
     """Retrieve prompts via the Pezzo client."""
 
     def __init__(self, project: str) -> None:
+        """Initialize the loader for the given Pezzo project."""
         from pezzo import PezzoClient
 
         self.client = PezzoClient(project=project)

--- a/prompti/loader/promptlayer.py
+++ b/prompti/loader/promptlayer.py
@@ -15,6 +15,7 @@ class PromptLayerLoader(TemplateLoader):
     URL = "https://api.promptlayer.com/prompt-templates"
 
     def __init__(self, api_key: str, client: httpx.AsyncClient | None = None) -> None:
+        """Create the loader with API key and optional HTTP client."""
         self.api_key = api_key
         self.client = client or httpx.AsyncClient()
 

--- a/prompti/model_client/base.py
+++ b/prompti/model_client/base.py
@@ -133,7 +133,6 @@ class ModelClient:
         self, cfg: ModelConfig, client: httpx.AsyncClient | None = None, is_debug: bool = False, **_: Any
     ) -> None:
         """Create the client with static :class:`ModelConfig` and optional HTTP client."""
-
         self.cfg = cfg
         self._client = client or httpx.AsyncClient(http2=True)
         self._tracer = trace.get_tracer(__name__)

--- a/prompti/model_client/litellm.py
+++ b/prompti/model_client/litellm.py
@@ -18,6 +18,7 @@ class LiteLLMClient(ModelClient):
     provider = "litellm"
 
     def __init__(self, cfg: ModelConfig, client: httpx.AsyncClient | None = None, is_debug: bool = False) -> None:
+        """Instantiate the client with configuration and optional HTTP client."""
         super().__init__(cfg, client, is_debug=is_debug)
         self.api_url = cfg.api_url
         self.api_key_var = cfg.api_key_var
@@ -29,7 +30,6 @@ class LiteLLMClient(ModelClient):
         p: RunParams,
     ) -> AsyncGenerator[Message, None]:
         """Translate A2A messages and execute via :func:`litellm.acompletion`."""
-
         is_claude = self.cfg.model.startswith("claude")
         oa_messages: list[dict[str, Any]] = []
         claude_msgs: list[dict[str, Any]] = []

--- a/prompti/replay.py
+++ b/prompti/replay.py
@@ -32,6 +32,7 @@ class ModelClientRecorder(ModelClient):
         session_id: str,
         output_dir: str | Path | None = None,
     ) -> None:
+        """Wrap ``client`` and log all interactions under ``session_id``."""
         super().__init__(client.cfg, client=client._client)
         self._wrapped = client
         self.session_id = session_id
@@ -78,6 +79,7 @@ class ModelClientRecorder(ModelClient):
                 raise
 
     async def close(self) -> None:
+        """Close the underlying client."""
         await self._wrapped.close()
 
 
@@ -86,7 +88,6 @@ class ReplayEngine:
 
     def __init__(self, client_factory: Callable[[str], ModelClient]):
         """Create with a ``client_factory`` mapping provider -> ModelClient."""
-
         self._client_factory = client_factory
         self._clients: dict[str, ModelClient] = {}
 
@@ -101,6 +102,7 @@ class ReplayEngine:
         up_to_step: int | None = None,
         patch: dict[int, list[Message]] | None = None,
     ) -> AsyncGenerator[Message, None]:
+        """Replay a recorded session and optionally patch messages."""
         patch = patch or {}
         status = "ok"
         try:


### PR DESCRIPTION
## Summary
- add docstrings for loader `__init__` methods
- add docstrings for replay module methods
- ensure docstring sections have trailing blank lines
- fix D202 issues in client initialization

## Testing
- `ruff check --select D prompti`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685c9fecf63c8320aeb5365069594ff1