### PR TITLE
Replace FileNotFoundError with TemplateNotFoundError

### DIFF
--- a/prompti/__init__.py
+++ b/prompti/__init__.py
@@ -19,6 +19,7 @@ from .loader import (
     PezzoLoader,
     PromptLayerLoader,
     TemplateLoader,
+    TemplateNotFoundError,
 )
 from .message import Kind, Message
 from .model_client import (
@@ -55,6 +56,7 @@ __all__ = [
     "bucket",
     "Kind",
     "TemplateLoader",
+    "TemplateNotFoundError",
     "HTTPLoader",
     "FileSystemLoader",
     "MemoryLoader",

--- a/prompti/engine.py
+++ b/prompti/engine.py
@@ -10,7 +10,13 @@ from async_lru import alru_cache
 from opentelemetry import trace
 from pydantic import BaseModel
 
-from .loader import FileSystemLoader, HTTPLoader, MemoryLoader, TemplateLoader
+from .loader import (
+    FileSystemLoader,
+    HTTPLoader,
+    MemoryLoader,
+    TemplateLoader,
+    TemplateNotFoundError,
+)
 from .message import Message
 from .model_client import ModelClient, RunParams, ToolParams, ToolSpec
 from .template import PromptTemplate
@@ -36,7 +42,7 @@ class PromptEngine:
                 version = versions[0].id
                 tmpl = await loader.get_template(name, version)
                 return tmpl
-        raise FileNotFoundError(name)
+        raise TemplateNotFoundError(name)
 
     async def load(self, template_name: str) -> PromptTemplate:
         """Public entry: resolve & cache a template by name."""

--- a/prompti/loader/__init__.py
+++ b/prompti/loader/__init__.py
@@ -1,7 +1,7 @@
 """Template loaders package."""
 
 from .agenta import AgentaLoader
-from .base import TemplateLoader
+from .base import TemplateLoader, TemplateNotFoundError
 from .file import FileSystemLoader
 from .github_repo import GitHubRepoLoader
 from .http import HTTPLoader
@@ -13,6 +13,7 @@ from .promptlayer import PromptLayerLoader
 
 __all__ = [
     "TemplateLoader",
+    "TemplateNotFoundError",
     "FileSystemLoader",
     "MemoryLoader",
     "HTTPLoader",

--- a/prompti/loader/agenta.py
+++ b/prompti/loader/agenta.py
@@ -5,7 +5,7 @@ import asyncio
 import yaml
 
 from ..template import PromptTemplate, Variant
-from .base import TemplateLoader, VersionEntry
+from .base import TemplateLoader, VersionEntry, TemplateNotFoundError
 
 
 class AgentaLoader(TemplateLoader):
@@ -55,11 +55,15 @@ class AgentaLoader(TemplateLoader):
                 variant_version=version,
             )
         except Exception:
-            raise FileNotFoundError(f"Template {name} version {version} not found")
+            raise TemplateNotFoundError(
+                f"Template {name} version {version} not found"
+            )
 
         yaml_blob = yaml.safe_dump(cfg["prompt"])
         if not yaml_blob:
-            raise FileNotFoundError(f"Template {name} version {version} has no prompt content")
+            raise TemplateNotFoundError(
+                f"Template {name} version {version} has no prompt content"
+            )
 
         meta = yaml.safe_load(yaml_blob)
         tmpl = PromptTemplate(

--- a/prompti/loader/base.py
+++ b/prompti/loader/base.py
@@ -8,6 +8,12 @@ from pydantic import BaseModel, Field
 from ..template import PromptTemplate
 
 
+class TemplateNotFoundError(Exception):
+    """Raised when a template cannot be located by a loader."""
+
+
+
+
 class VersionEntry(BaseModel):
     """Represents a version of a template with its ID and tags."""
 

--- a/prompti/loader/file.py
+++ b/prompti/loader/file.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import yaml
 
 from ..template import PromptTemplate, Variant
-from .base import TemplateLoader, VersionEntry
+from .base import TemplateLoader, VersionEntry, TemplateNotFoundError
 
 
 class FileSystemLoader(TemplateLoader):
@@ -38,7 +38,7 @@ class FileSystemLoader(TemplateLoader):
         """Load and return the template identified by name and version."""
         path = self.base / f"{name}.yaml"
         if not path.exists():
-            raise FileNotFoundError(name)
+            raise TemplateNotFoundError(name)
 
         text = path.read_text()
         data = yaml.safe_load(text)
@@ -46,7 +46,7 @@ class FileSystemLoader(TemplateLoader):
 
         # Check if the requested version matches
         if version != template_version:
-            raise FileNotFoundError(f"Version {version} not found for template {name}")
+            raise TemplateNotFoundError(f"Version {version} not found for template {name}")
 
         tmpl = PromptTemplate(
             id=name,

--- a/prompti/loader/http.py
+++ b/prompti/loader/http.py
@@ -4,7 +4,7 @@ import httpx
 import yaml
 
 from ..template import PromptTemplate, Variant
-from .base import TemplateLoader, VersionEntry
+from .base import TemplateLoader, VersionEntry, TemplateNotFoundError
 
 
 class HTTPLoader(TemplateLoader):
@@ -31,7 +31,9 @@ class HTTPLoader(TemplateLoader):
         """Retrieve specific version of template from the remote registry."""
         resp = await self.client.get(f"{self.base_url}/templates/{name}/{version}")
         if resp.status_code != 200:
-            raise FileNotFoundError(f"Template {name} version {version} not found")
+            raise TemplateNotFoundError(
+                f"Template {name} version {version} not found"
+            )
 
         data = resp.json()
         text = data.get("yaml", "")

--- a/prompti/loader/langfuse.py
+++ b/prompti/loader/langfuse.py
@@ -5,7 +5,7 @@ import asyncio
 import yaml
 
 from ..template import PromptTemplate, Variant
-from .base import TemplateLoader, VersionEntry
+from .base import TemplateLoader, VersionEntry, TemplateNotFoundError
 
 
 class LangfuseLoader(TemplateLoader):
@@ -52,11 +52,15 @@ class LangfuseLoader(TemplateLoader):
         try:
             prm = await asyncio.to_thread(self.client.prompts().get_prompt, name, version=int(version))
         except Exception:
-            raise FileNotFoundError(f"Template {name} version {version} not found")
+            raise TemplateNotFoundError(
+                f"Template {name} version {version} not found"
+            )
 
         yaml_blob = prm.yaml
         if not yaml_blob:
-            raise FileNotFoundError(f"Template {name} version {version} has no YAML content")
+            raise TemplateNotFoundError(
+                f"Template {name} version {version} has no YAML content"
+            )
 
         meta = yaml.safe_load(yaml_blob)
         tmpl = PromptTemplate(

--- a/prompti/loader/local_git_repo.py
+++ b/prompti/loader/local_git_repo.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import yaml
 
 from ..template import PromptTemplate, Variant
-from .base import TemplateLoader, VersionEntry
+from .base import TemplateLoader, VersionEntry, TemplateNotFoundError
 
 
 class LocalGitRepoLoader(TemplateLoader):
@@ -42,14 +42,16 @@ class LocalGitRepoLoader(TemplateLoader):
         commit_version = str(commit.hex[:7])
 
         if version != commit_version:
-            raise FileNotFoundError(f"Version {version} not available, current commit is {commit_version}")
+            raise TemplateNotFoundError(
+                f"Version {version} not available, current commit is {commit_version}"
+            )
 
         try:
             tree = commit.tree
             blob = tree[f"prompts/{name}.yaml"]
             text = blob.data.decode()
         except KeyError:
-            raise FileNotFoundError(f"Template {name} not found")
+            raise TemplateNotFoundError(f"Template {name} not found")
 
         meta = yaml.safe_load(text)
         tmpl = PromptTemplate(

--- a/prompti/loader/memory.py
+++ b/prompti/loader/memory.py
@@ -3,7 +3,7 @@
 import yaml
 
 from ..template import PromptTemplate, Variant
-from .base import TemplateLoader, VersionEntry
+from .base import TemplateLoader, VersionEntry, TemplateNotFoundError
 
 
 class MemoryLoader(TemplateLoader):
@@ -30,7 +30,7 @@ class MemoryLoader(TemplateLoader):
         """Return the template for the specific version."""
         data = self.mapping.get(name)
         if not data:
-            raise FileNotFoundError(name)
+            raise TemplateNotFoundError(name)
 
         text = data.get("yaml", "")
         ydata = yaml.safe_load(text) if text else {}
@@ -38,7 +38,7 @@ class MemoryLoader(TemplateLoader):
 
         # Check if the requested version matches
         if version != template_version:
-            raise FileNotFoundError(f"Version {version} not found for template {name}")
+            raise TemplateNotFoundError(f"Version {version} not found for template {name}")
 
         tmpl = PromptTemplate(
             id=name,

--- a/prompti/loader/pezzo.py
+++ b/prompti/loader/pezzo.py
@@ -3,7 +3,7 @@
 import yaml
 
 from ..template import PromptTemplate, Variant
-from .base import TemplateLoader, VersionEntry
+from .base import TemplateLoader, VersionEntry, TemplateNotFoundError
 
 
 class PezzoLoader(TemplateLoader):
@@ -37,11 +37,15 @@ class PezzoLoader(TemplateLoader):
         try:
             prompt = await self.client.get_prompt(slug=name, environment="production", version=version)
         except Exception:
-            raise FileNotFoundError(f"Template {name} version {version} not found")
+            raise TemplateNotFoundError(
+                f"Template {name} version {version} not found"
+            )
 
         yaml_blob = prompt["yaml"]
         if not yaml_blob:
-            raise FileNotFoundError(f"Template {name} version {version} has no YAML content")
+            raise TemplateNotFoundError(
+                f"Template {name} version {version} has no YAML content"
+            )
 
         meta = yaml.safe_load(yaml_blob)
         tmpl = PromptTemplate(

--- a/prompti/loader/promptlayer.py
+++ b/prompti/loader/promptlayer.py
@@ -6,7 +6,7 @@ import httpx
 import yaml
 
 from ..template import ModelConfig, PromptTemplate, Variant
-from .base import TemplateLoader, VersionEntry
+from .base import TemplateLoader, VersionEntry, TemplateNotFoundError
 
 
 class PromptLayerLoader(TemplateLoader):
@@ -61,7 +61,9 @@ class PromptLayerLoader(TemplateLoader):
             json=body,
         )
         if resp.status_code != 200:
-            raise FileNotFoundError(f"Template {name} version {version} not found")
+            raise TemplateNotFoundError(
+                f"Template {name} version {version} not found"
+            )
 
         data = resp.json()
         content = data["prompt_template"]["content"]

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -3,7 +3,12 @@ from pathlib import Path
 import pytest
 
 from prompti.engine import PromptEngine
-from prompti.loader import FileSystemLoader, MemoryLoader, TemplateLoader
+from prompti.loader import (
+    FileSystemLoader,
+    MemoryLoader,
+    TemplateLoader,
+    TemplateNotFoundError,
+)
 from prompti.message import Message
 from prompti.model_client import ModelClient, ModelConfig, RunParams
 from prompti.template import PromptTemplate, Variant
@@ -87,5 +92,5 @@ async def test_load_caches_result():
 @pytest.mark.asyncio
 async def test_load_missing_raises():
     engine = PromptEngine([FileSystemLoader(Path("./prompts"))])
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(TemplateNotFoundError):
         await engine.load("nonexistent")

--- a/tests/test_version_selector.py
+++ b/tests/test_version_selector.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from prompti.loader.base import TemplateLoader, VersionEntry
+from prompti.loader.base import TemplateLoader, TemplateNotFoundError, VersionEntry
 from prompti.loader.memory import MemoryLoader
 
 
@@ -419,7 +419,7 @@ variants:
         }
         loader = MemoryLoader(mapping)
 
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(TemplateNotFoundError):
             await loader.get_template("test_template", "2.0.0")
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add `TemplateNotFoundError` in loader base
- update all loaders and engine to use the new error
- export the error from `prompti` and `prompti.loader`
- update tests to expect `TemplateNotFoundError`

## Testing
- `pip install -e .[test]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ca736c08483209531f393cb4eaf5d