### PR TITLE
Add tag-only version selector support

### DIFF
--- a/prompti/loader/base.py
+++ b/prompti/loader/base.py
@@ -129,7 +129,15 @@ class TemplateLoader(ABC):
             return None
 
         # Handle different version spec formats
-        if TemplateLoader._is_version_range(version_spec):
+        if version_spec == "":
+            # Return the highest version among candidates
+            sorted_candidates = sorted(
+                candidates,
+                key=lambda c: TemplateLoader._parse_version_for_sorting(c.id),
+                reverse=True,
+            )
+            return sorted_candidates[0] if sorted_candidates else None
+        elif TemplateLoader._is_version_range(version_spec):
             return TemplateLoader._select_from_range(candidates, version_spec)
         elif version_spec.endswith(".x"):
             return TemplateLoader._select_from_wildcard(candidates, version_spec)
@@ -168,7 +176,7 @@ class TemplateLoader(ABC):
             required_tags = []
 
         version_spec = version_spec.strip()
-        if not version_spec:
+        if not version_spec and not required_tags:
             raise ValueError("Version specification cannot be empty")
 
         return version_spec, required_tags

--- a/tests/test_version_selector.py
+++ b/tests/test_version_selector.py
@@ -60,10 +60,11 @@ class TestVersionSelectorParsing:
         with pytest.raises(ValueError, match="Version selector cannot be empty"):
             TemplateLoader._parse_version_selector("")
 
-    def test_parse_empty_version_spec(self):
-        """Test parsing selector with empty version spec raises error."""
-        with pytest.raises(ValueError, match="Version specification cannot be empty"):
-            TemplateLoader._parse_version_selector("#prod")
+    def test_parse_tag_only_selector(self):
+        """Test parsing selector that only specifies tags."""
+        version_spec, tags = TemplateLoader._parse_version_selector("#prod")
+        assert version_spec == ""
+        assert tags == ["prod"]
 
     def test_parse_tags_with_whitespace(self):
         """Test parsing tags with extra whitespace."""
@@ -300,6 +301,18 @@ class TestVersionSelectionStatic:
         # Impossible combination
         selected = TemplateLoader.select_version(versions, "1.x#prod+stable+lts+nonexistent")
         assert selected is None
+
+    def test_select_tag_only(self):
+        """Select highest version when only a tag is specified."""
+        versions = [
+            VersionEntry(id="1.0.0", tags=["prod"]),
+            VersionEntry(id="1.1.0", tags=["beta"]),
+            VersionEntry(id="2.0.0", tags=["prod"]),
+        ]
+
+        selected = TemplateLoader.select_version(versions, "#prod")
+        assert selected is not None
+        assert selected.id == "2.0.0"
 
 
 class TestVersionSelectorFormats:


### PR DESCRIPTION
## Summary
- allow tag-only selector strings (e.g. `#prod`)
- pick the highest matching version when only tags are specified
- add tests covering tag-only parsing and selection

## Testing
- `pytest tests/test_version_selector.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cd43721448320b3eeecf7ce5315d7