### PR TITLE
Rename ctx_to_flat helper

### DIFF
--- a/prompti/template.py
+++ b/prompti/template.py
@@ -28,9 +28,9 @@ _format_latency = Histogram(
 SNAKE = re.compile(r"^[a-z][a-z0-9_]*$")
 
 
-def _ctx_to_flat(ctx: dict[str, Any]) -> str:
-    """Flatten context to a lowercase JSON string for token matching."""
-    return json.dumps(ctx, separators=(",", ":")).lower()
+def _selector_to_flat(selector: dict[str, Any]) -> str:
+    """Flatten selector to a lowercase JSON string for token matching."""
+    return json.dumps(selector, separators=(",", ":")).lower()
 
 
 class Variant(BaseModel):
@@ -55,7 +55,7 @@ class PromptTemplate(BaseModel):
 
     def choose_variant(self, selector: dict[str, Any]) -> str | None:
         """Return the first variant id whose tokens all appear in ``selector``."""
-        haystack = _ctx_to_flat(selector)
+        haystack = _selector_to_flat(selector)
         for vid, var in self.variants.items():
             if all(tok.lower() in haystack for tok in var.selector):
                 return vid


### PR DESCRIPTION
## Summary
- rename `_ctx_to_flat` to `_selector_to_flat`

## Testing
- `pip install -e .[test]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cd45d266c83208e62351fdf08a877