### PR TITLE
Support global model config fallbacks

### DIFF
--- a/prompti/model_config_loader.py
+++ b/prompti/model_config_loader.py
@@ -1,0 +1,50 @@
+"""Load ModelConfig objects from various sources."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+import httpx
+import yaml
+
+from .model_client import ModelConfig
+
+
+class ModelConfigLoader(ABC):
+    """Base class for loaders that return a :class:`ModelConfig`."""
+
+    @abstractmethod
+    def load(self) -> ModelConfig:
+        """Return a :class:`ModelConfig` instance."""
+        raise NotImplementedError
+
+
+class FileModelConfigLoader(ModelConfigLoader):
+    """Load a model configuration from a local YAML or JSON file."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+
+    def load(self) -> ModelConfig:
+        text = self.path.read_text()
+        data = yaml.safe_load(text)
+        if not isinstance(data, dict):
+            raise ValueError("Config file must contain a mapping")
+        return ModelConfig(**data)
+
+
+class HTTPModelConfigLoader(ModelConfigLoader):
+    """Fetch model configuration from an HTTP endpoint returning JSON."""
+
+    def __init__(self, url: str, client: httpx.Client | None = None) -> None:
+        self.url = url
+        self.client = client or httpx.Client()
+
+    def load(self) -> ModelConfig:
+        resp = self.client.get(self.url)
+        resp.raise_for_status()
+        data = resp.json()
+        if not isinstance(data, dict):
+            raise ValueError("Config response must be a JSON object")
+        return ModelConfig(**data)

--- a/prompti/template.py
+++ b/prompti/template.py
@@ -37,7 +37,7 @@ class Variant(BaseModel):
     """Single experiment arm."""
 
     selector: list[str] = []
-    model_cfg: ModelConfig = Field(..., alias="model_config")
+    model_cfg: ModelConfig | None = Field(None, alias="model_config")
     messages: list[dict]
     tools: list[dict] | None = None
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2,7 +2,8 @@ from pathlib import Path
 
 import pytest
 
-from prompti.engine import PromptEngine
+from prompti.engine import PromptEngine, Setting
+from prompti.model_config_loader import ModelConfigLoader
 from prompti.loader import (
     FileSystemLoader,
     MemoryLoader,
@@ -19,6 +20,14 @@ class DummyClient(ModelClient):
 
     async def _run(self, params: RunParams):
         yield Message(role="assistant", kind="text", content="ok")
+
+
+class DummyConfigLoader(ModelConfigLoader):
+    def __init__(self, cfg: ModelConfig) -> None:
+        self.cfg = cfg
+
+    def load(self) -> ModelConfig:
+        return self.cfg
 
 
 @pytest.mark.asyncio
@@ -94,3 +103,69 @@ async def test_load_missing_raises():
     engine = PromptEngine([FileSystemLoader(Path("./prompts"))])
     with pytest.raises(TemplateNotFoundError):
         await engine.load("nonexistent")
+
+
+@pytest.mark.asyncio
+async def test_global_model_config_used_when_variant_missing():
+    yaml_text = """
+name: x
+version: '1'
+variants:
+  base:
+    selector: []
+    messages:
+      - role: user
+        parts: []
+"""
+    setting = Setting(
+        memory_templates={"x": {"yaml": yaml_text}},
+        global_config_loader=DummyConfigLoader(ModelConfig(provider="dummy", model="z")),
+    )
+    engine = PromptEngine.from_setting(setting)
+    client = DummyClient(ModelConfig(provider="dummy", model="y"))
+    out = [m async for m in engine.run("x", {}, client=client, variant="base", stream=False)]
+    assert out[0].content == "ok"
+    assert client.cfg == ModelConfig(provider="dummy", model="z")
+
+
+@pytest.mark.asyncio
+async def test_variant_overrides_global_model_config():
+    yaml_text = """
+name: x
+version: '1'
+variants:
+  base:
+    selector: []
+    model_config:
+      provider: dummy
+      model: x
+    messages:
+      - role: user
+        parts: []
+"""
+    setting = Setting(
+        memory_templates={"x": {"yaml": yaml_text}},
+        global_config_loader=DummyConfigLoader(ModelConfig(provider="dummy", model="z")),
+    )
+    engine = PromptEngine.from_setting(setting)
+    client = DummyClient(ModelConfig(provider="dummy", model="y"))
+    out = [m async for m in engine.run("x", {}, client=client, variant="base", stream=False)]
+    assert client.cfg == ModelConfig(provider="dummy", model="x")
+
+
+@pytest.mark.asyncio
+async def test_error_when_no_model_config_available():
+    yaml_text = """
+name: x
+version: '1'
+variants:
+  base:
+    selector: []
+    messages:
+      - role: user
+        parts: []
+"""
+    engine = PromptEngine([MemoryLoader({"x": {"yaml": yaml_text}})])
+    client = DummyClient(ModelConfig(provider="dummy", model="y"))
+    with pytest.raises(ValueError):
+        [m async for m in engine.run("x", {}, client=client, variant="base", stream=False)]


### PR DESCRIPTION
## Summary
- make `Variant.model_cfg` optional
- add `ModelConfigLoader` infrastructure with file and HTTP loaders
- allow `PromptEngine` to hold a global model config
- load global config using new loader in `PromptEngine.from_setting`
- default to this config in `PromptEngine.run`
- test global config behavior and overrides

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ce128015883209998f8a640b0f459