### PR TITLE
Add format option to PromptEngine.format

### DIFF
--- a/examples/template_format.py
+++ b/examples/template_format.py
@@ -12,22 +12,16 @@ async def main() -> None:
     """Render ``support_reply`` template and send via ``litellm``."""
     engine = PromptEngine.from_setting(Setting())
 
-    # Format the template using ``engine.format``
-    a2a_messages = await engine.format(
+    # Format the template directly as OpenAI messages and send
+    messages = await engine.format(
         "support_reply",
         {"name": "Ada", "issue": "login failed"},
+        format="openai",
     )
 
-    # Convert A2A messages to OpenAI/LiteLLM format
-    oa_messages = [
-        {"role": m.role, "content": m.content}
-        for m in a2a_messages
-    ]
-
-    # Send to LiteLLM using the rendered messages
     response = await litellm.acompletion(
         model=os.getenv("MODEL_NAME", "gpt-3.5-turbo"),
-        messages=oa_messages,
+        messages=messages,
         api_key=os.getenv("LITELLM_API_KEY"),
         base_url=os.getenv("LITELLM_ENDPOINT"),
     )

--- a/prompti/engine.py
+++ b/prompti/engine.py
@@ -62,10 +62,11 @@ class PromptEngine:
         *,
         variant: str | None = None,
         ctx: dict[str, Any] | None = None,
-    ) -> list[Message]:
-        """Return formatted messages for ``template_name``."""
+        format: str = "a2a",
+    ) -> list[Message] | list[dict]:
+        """Return formatted messages for ``template_name`` in ``format``."""
         tmpl = await self._resolve(template_name, None)
-        msgs, _ = tmpl.format(variables, variant=variant, ctx=ctx, format="a2a")
+        msgs, _ = tmpl.format(variables, variant=variant, ctx=ctx, format=format)
         return msgs
 
     async def run(

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -169,3 +169,23 @@ variants:
     client = DummyClient(ModelConfig(provider="dummy", model="y"))
     with pytest.raises(ValueError):
         [m async for m in engine.run("x", {}, client=client, variant="base", stream=False)]
+
+
+@pytest.mark.asyncio
+async def test_engine_format_openai():
+    yaml_text = """
+name: greet
+version: '1'
+variants:
+  base:
+    selector: []
+    messages:
+      - role: user
+        parts:
+          - type: text
+            text: "Hello {{ name }}"
+"""
+
+    engine = PromptEngine([MemoryLoader({"greet": {"yaml": yaml_text}})])
+    msgs = await engine.format("greet", {"name": "Ada"}, variant="base", format="openai")
+    assert msgs == [{"role": "user", "content": "Hello Ada"}]


### PR DESCRIPTION
## Summary
- allow selecting output format from PromptEngine.format
- update example to request OpenAI format directly
- test PromptEngine.format with OpenAI output

## Testing
- `uv pip install --system -e .[test]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cec1bd9e08320a76c7dd56bb16b62