### PR TITLE
Rename ctx param

### DIFF
--- a/prompti/engine.py
+++ b/prompti/engine.py
@@ -61,12 +61,17 @@ class PromptEngine:
         variables: dict[str, Any],
         *,
         variant: str | None = None,
-        ctx: dict[str, Any] | None = None,
+        selector: dict[str, Any] | None = None,
         format: str = "a2a",
     ) -> list[Message] | list[dict]:
         """Return formatted messages for ``template_name`` in ``format``."""
         tmpl = await self._resolve(template_name, None)
-        msgs, _ = tmpl.format(variables, variant=variant, ctx=ctx, format=format)
+        msgs, _ = tmpl.format(
+            variables,
+            variant=variant,
+            selector=selector,
+            format=format,
+        )
         return msgs
 
     async def run(
@@ -87,7 +92,12 @@ class PromptEngine:
         if variant is None:
             variant = tmpl.choose_variant(ctx) or next(iter(tmpl.variants))
 
-        messages, var = tmpl.format(variables, variant=variant, ctx=ctx, format="a2a")
+        messages, var = tmpl.format(
+            variables,
+            variant=variant,
+            selector=ctx,
+            format="a2a",
+        )
         params = RunParams(messages=messages, tool_params=tool_params, **run_params)
 
         with _tracer.start_as_current_span(

--- a/prompti/template.py
+++ b/prompti/template.py
@@ -101,7 +101,7 @@ class PromptTemplate(BaseModel):
         variables: dict[str, Any],
         *,
         variant: str | None = None,
-        ctx: dict[str, Any] | None = None,
+        selector: dict[str, Any] | None = None,
         format: str = "openai",
     ) -> tuple[list[Message] | list[dict], Variant]:
         """Render the template and return messages in the requested format.
@@ -112,8 +112,8 @@ class PromptTemplate(BaseModel):
         """
         start = perf_counter()
         try:
-            ctx = ctx or variables
-            variant = variant or self.choose_variant(ctx) or next(iter(self.variants))
+            selector = selector or variables
+            variant = variant or self.choose_variant(selector) or next(iter(self.variants))
             var = self.variants[variant]
             fmt = format.lower()
 


### PR DESCRIPTION
## Summary
- rename `ctx` to `selector` in `PromptTemplate.format`
- rename `ctx` to `selector` in `PromptEngine.format`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cee0d72e0832086199d51b3c8d5ed