### PR TITLE
fix: suppress F401 lint warning for optional LiteLLMClient import

### DIFF
--- a/src/prompti/__init__.py
+++ b/src/prompti/__init__.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-
 from .engine import PromptEngine
 from .experiment import (
     ExperimentRegistry,
@@ -69,10 +68,11 @@ __all__ = [
     "LocalGitRepoLoader",
 ]
 
-# Optional imports
+# Optional imports - only available when litellm is installed
 try:
-    from .model_client import LiteLLMClient
+    from .model_client import LiteLLMClient  # noqa: F401
 
     __all__.append("LiteLLMClient")
 except ImportError:
+    # LiteLLMClient not available - litellm dependency not installed
     pass

--- a/src/prompti/model_client/__init__.py
+++ b/src/prompti/model_client/__init__.py
@@ -26,7 +26,7 @@ __all__ = [
 
 # Optional import for LiteLLMClient
 try:
-    from .litellm import LiteLLMClient
+    from .litellm import LiteLLMClient  # noqa: F401
 
     __all__.append("LiteLLMClient")
 except ImportError:


### PR DESCRIPTION
Fixes Ruff F401 lint warning for the optional LiteLLMClient import in __init__.py

## 🐛 Issue
- Ruff was flagging LiteLLMClient as 'imported but unused' 
- The import is intentional for optional dependency pattern

## ✅ Solution  
- Added descriptive comment explaining the optional import pattern
- Added `# noqa: F401` to suppress the specific warning
- Enhanced error handling comment for clarity

## 🧪 Testing
- Lint warning resolved
- Import behavior unchanged
- Optional dependency pattern still works correctly

Small fix to keep the codebase clean! 🧹